### PR TITLE
Added Vim script backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ COBJS := $(addprefix out/,$(notdir $(CSRCS:.c=.o)))
 $(COBJS): out/%.o: ir/%.c
 	$(CC) -c -I. $(CFLAGS) $< -o $@
 
-ELC_SRCS := elc.c util.c rb.c py.c js.c el.c sh.c java.c c.c x86.c i.c ws.c piet.c pietasm.c bef.c bf.c unl.c
+ELC_SRCS := elc.c util.c rb.c py.c js.c el.c vim.c sh.c java.c c.c x86.c i.c ws.c piet.c pietasm.c bef.c bf.c unl.c
 ELC_SRCS := $(addprefix target/,$(ELC_SRCS))
 COBJS := $(addprefix out/,$(notdir $(ELC_SRCS:.c=.o)))
 $(COBJS): out/%.o: target/%.c
@@ -178,6 +178,10 @@ include target.mk
 
 TARGET := el
 RUNNER := emacs --no-site-file --script
+include target.mk
+
+TARGET := vim
+RUNNER := tools/runvim.sh
 include target.mk
 
 TARGET := sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently, there are 14 backends:
 * JavaScript
 * Java
 * Emacs Lisp
+* Vim script
 * Bash
 * C
 * i386-linux
@@ -168,6 +169,18 @@ backends. You can run a C compiler on Emacs:
 * M-x elc
 * M-x eval-buffer
 * M-x elvm-main
+
+### Vim script
+
+You can run a C compiler on Vim:
+
+* Open test/hello.c (or write your C code)
+* `:source /path/to/out/8cc.vim`
+* Now you can see ELVM IR in the buffer
+* Please prepend a backend name (`vim` for Vim) to the first line
+* `:source /path/to/out/elc.vim`
+* You can see Vim script code as the compilation result in current buffer
+* You can `:source` to run the code
 
 ## Future works
 

--- a/target/elc.c
+++ b/target/elc.c
@@ -9,6 +9,7 @@ void target_rb(Module* module);
 void target_py(Module* module);
 void target_js(Module* module);
 void target_el(Module* module);
+void target_vim(Module* module);
 void target_sh(Module* module);
 void target_java(Module* module);
 void target_c(Module* module);
@@ -31,6 +32,8 @@ static target_func_t get_target_func(const char* ext) {
     return target_js;
   } else if (!strcmp(ext, "el")) {
     return target_el;
+  } else if (!strcmp(ext, "vim")) {
+    return target_vim;
   } else if (!strcmp(ext, "sh")) {
     return target_sh;
   } else if (!strcmp(ext, "java")) {

--- a/target/vim.c
+++ b/target/vim.c
@@ -1,0 +1,164 @@
+#include <ir/ir.h>
+#include <target/util.h>
+
+static const char* REG_NAMES_VIM[] = {
+  "s:a", "s:b", "s:c", "s:d", "s:bp", "s:sp", "s:pc"
+};
+
+static void init_state_vim(Data* data) {
+  reg_names = REG_NAMES_VIM;
+  for (int i = 0; i < 7; i++) {
+    emit_line("let %s = 0", reg_names[i]);
+  }
+  emit_line("let s:mem = repeat([0], 16777216)");
+  for (int mp = 0; data; data = data->next, mp++) {
+    if (data->v) {
+      emit_line("let s:mem[%d] = %d", mp, data->v);
+    }
+  }
+  emit_line("let s:input = map(split(join(getline(1, '$'), \"\\n\"), '\\zs'), 'char2nr(v:val)')");
+  emit_line("let s:ic = 0");
+  emit_line("let s:output = []");
+  emit_line("normal! dG");
+}
+
+static void vim_emit_func_prologue(int func_id) {
+  emit_line("");
+  emit_line("function! Func%d()", func_id);
+  inc_indent();
+  emit_line("while %d <= s:pc && s:pc < %d",
+            func_id * CHUNKED_FUNC_SIZE, (func_id + 1) * CHUNKED_FUNC_SIZE);
+  inc_indent();
+  emit_line("if 0");
+  inc_indent();
+}
+
+static void vim_emit_func_epilogue(void) {
+  dec_indent();
+  emit_line("endif");
+  emit_line("let s:pc += 1");
+  dec_indent();
+  emit_line("endwhile");
+  dec_indent();
+  emit_line("endfunction");
+}
+
+static void vim_emit_pc_change(int pc) {
+  emit_line("");
+  dec_indent();
+  emit_line("elseif s:pc == %d", pc);
+  inc_indent();
+}
+
+static void vim_emit_inst(Inst* inst) {
+  switch (inst->op) {
+  case MOV:
+    emit_line("let %s = %s", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case ADD:
+    emit_line("let %s = and((%s + %s), " UINT_MAX_STR ")",
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case SUB:
+    emit_line("let %s = and((%s - %s), " UINT_MAX_STR ")",
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case LOAD:
+    emit_line("let %s = s:mem[%s]", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case STORE:
+    emit_line("let s:mem[%s] = %s", src_str(inst), reg_names[inst->dst.reg]);
+    break;
+
+  case PUTC:
+    emit_line("let s:output += [%s]", src_str(inst));
+    break;
+
+  case GETC:
+    emit_line("let %s = len(s:input) <= s:ic ? 0 : s:input[s:ic]", reg_names[inst->dst.reg]);
+    emit_line("let s:ic += 1");
+    break;
+
+  case EXIT:
+    emit_line("if len(s:output) == 0 | return 1 | endif");
+    emit_line("let s:lines = ['']");
+    emit_line("for s:ch in s:output");
+    inc_indent();
+    emit_line("if s:ch == 10");
+    inc_indent();
+    emit_line("let s:lines += ['']");
+    dec_indent();
+    emit_line("else");
+    inc_indent();
+    emit_line("let s:lines[len(s:lines)-1] .= nr2char(s:ch == 0 ? 10 : s:ch)");
+    dec_indent();
+    emit_line("endif");
+    emit_line("unlet s:ch");
+    dec_indent();
+    emit_line("endfor");
+    emit_line("call setline(1, s:lines)");
+    emit_line("return 1");
+    break;
+
+  case DUMP:
+    break;
+
+  case EQ:
+  case NE:
+  case LT:
+  case GT:
+  case LE:
+  case GE:
+    emit_line("let %s = %s ? 1 : 0",
+              reg_names[inst->dst.reg], cmp_str(inst, "1"));
+    break;
+
+  case JEQ:
+  case JNE:
+  case JLT:
+  case JGT:
+  case JLE:
+  case JGE:
+  case JMP:
+    emit_line("if %s", cmp_str(inst, "1"));
+    inc_indent();
+    emit_line("let s:pc = %s - 1", value_str(&inst->jmp));
+    dec_indent();
+    emit_line("endif");
+    break;
+
+  default:
+    error("oops");
+  }
+}
+
+void target_vim(Module* module) {
+  init_state_vim(module->data);
+  emit_line("");
+
+  int num_funcs = emit_chunked_main_loop(module->text,
+                                         vim_emit_func_prologue,
+                                         vim_emit_func_epilogue,
+                                         vim_emit_pc_change,
+                                         vim_emit_inst);
+
+  emit_line("");
+  emit_line("while 1");
+  inc_indent();
+  emit_line("if 0");
+  for (int i = 0; i < num_funcs; i++) {
+    emit_line("elseif s:pc < %d", (i + 1) * CHUNKED_FUNC_SIZE);
+    inc_indent();
+    emit_line("if Func%d() | break | endif", i);
+    dec_indent();
+  }
+  emit_line("endif");
+  dec_indent();
+  emit_line("endwhile");
+}

--- a/tools/runvim.sh
+++ b/tools/runvim.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Runs Vim script code by Ex mode with silent mode.
+# Only readfile() can treat binary input (e.g. input without EOL at the end of file) properly in Vim.
+# This script saves stdin to /tmp/out and outputs the result (stdout) to /tmp/out after :source the script.
+
 cat > /tmp/out
 TERM=dumb vim -X -N -b -n -u NONE -i NONE -V1 -e -s --cmd "call setline(1, readfile('/tmp/out', 'b')) | set noeol | source $1 | w! /tmp/out | qa!" > /dev/null 2>&1
 cat /tmp/out

--- a/tools/runvim.sh
+++ b/tools/runvim.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat > /tmp/out
+TERM=dumb vim -X -N -b -n -u NONE -i NONE -V1 -e -s --cmd "call setline(1, readfile('/tmp/out', 'b')) | set noeol | source $1 | w! /tmp/out | qa!" > /dev/null 2>&1
+cat /tmp/out


### PR DESCRIPTION
I added Vim script backend. It was a lot of fun.  Thank you for a nice project 😄 

I confirmed all tests passed as below:

<details>
out/elc -vim out/00exit.eir > out/00exit.eir.vim.tmp && chmod 755 out/00exit.eir.vim.tmp && mv out/00exit.eir.vim.tmp out/00exit.eir.vim
out/elc -vim out/01putc.eir > out/01putc.eir.vim.tmp && chmod 755 out/01putc.eir.vim.tmp && mv out/01putc.eir.vim.tmp out/01putc.eir.vim
out/elc -vim out/02mov.eir > out/02mov.eir.vim.tmp && chmod 755 out/02mov.eir.vim.tmp && mv out/02mov.eir.vim.tmp out/02mov.eir.vim
out/elc -vim out/03mov_reg.eir > out/03mov_reg.eir.vim.tmp && chmod 755 out/03mov_reg.eir.vim.tmp && mv out/03mov_reg.eir.vim.tmp out/03mov_reg.eir.vim
out/elc -vim out/04getc.eir > out/04getc.eir.vim.tmp && chmod 755 out/04getc.eir.vim.tmp && mv out/04getc.eir.vim.tmp out/04getc.eir.vim
out/elc -vim out/05regjmp.eir > out/05regjmp.eir.vim.tmp && chmod 755 out/05regjmp.eir.vim.tmp && mv out/05regjmp.eir.vim.tmp out/05regjmp.eir.vim
out/elc -vim out/06mem.eir > out/06mem.eir.vim.tmp && chmod 755 out/06mem.eir.vim.tmp && mv out/06mem.eir.vim.tmp out/06mem.eir.vim
out/elc -vim out/07mem.eir > out/07mem.eir.vim.tmp && chmod 755 out/07mem.eir.vim.tmp && mv out/07mem.eir.vim.tmp out/07mem.eir.vim
out/elc -vim out/08data.eir > out/08data.eir.vim.tmp && chmod 755 out/08data.eir.vim.tmp && mv out/08data.eir.vim.tmp out/08data.eir.vim
out/elc -vim out/add_self.eir > out/add_self.eir.vim.tmp && chmod 755 out/add_self.eir.vim.tmp && mv out/add_self.eir.vim.tmp out/add_self.eir.vim
out/elc -vim out/basic.eir > out/basic.eir.vim.tmp && chmod 755 out/basic.eir.vim.tmp && mv out/basic.eir.vim.tmp out/basic.eir.vim
out/elc -vim out/bug_cmp.eir > out/bug_cmp.eir.vim.tmp && chmod 755 out/bug_cmp.eir.vim.tmp && mv out/bug_cmp.eir.vim.tmp out/bug_cmp.eir.vim
out/elc -vim out/echo.eir > out/echo.eir.vim.tmp && chmod 755 out/echo.eir.vim.tmp && mv out/echo.eir.vim.tmp out/echo.eir.vim
out/elc -vim out/isprint.eir > out/isprint.eir.vim.tmp && chmod 755 out/isprint.eir.vim.tmp && mv out/isprint.eir.vim.tmp out/isprint.eir.vim
out/elc -vim out/neg.eir > out/neg.eir.vim.tmp && chmod 755 out/neg.eir.vim.tmp && mv out/neg.eir.vim.tmp out/neg.eir.vim
out/elc -vim out/sub.eir > out/sub.eir.vim.tmp && chmod 755 out/sub.eir.vim.tmp && mv out/sub.eir.vim.tmp out/sub.eir.vim
out/elc -vim out/sub_bug.eir > out/sub_bug.eir.vim.tmp && chmod 755 out/sub_bug.eir.vim.tmp && mv out/sub_bug.eir.vim.tmp out/sub_bug.eir.vim
out/elc -vim out/cmps.eir > out/cmps.eir.vim.tmp && chmod 755 out/cmps.eir.vim.tmp && mv out/cmps.eir.vim.tmp out/cmps.eir.vim
out/elc -vim out/jmps.eir > out/jmps.eir.vim.tmp && chmod 755 out/jmps.eir.vim.tmp && mv out/jmps.eir.vim.tmp out/jmps.eir.vim
out/elc -vim out/24_mem.eir > out/24_mem.eir.vim.tmp && chmod 755 out/24_mem.eir.vim.tmp && mv out/24_mem.eir.vim.tmp out/24_mem.eir.vim
out/elc -vim out/bm_mov.eir > out/bm_mov.eir.vim.tmp && chmod 755 out/bm_mov.eir.vim.tmp && mv out/bm_mov.eir.vim.tmp out/bm_mov.eir.vim
out/elc -vim out/func2.c.eir > out/func2.c.eir.vim.tmp && chmod 755 out/func2.c.eir.vim.tmp && mv out/func2.c.eir.vim.tmp out/func2.c.eir.vim
out/elc -vim out/fizzbuzz.c.eir > out/fizzbuzz.c.eir.vim.tmp && chmod 755 out/fizzbuzz.c.eir.vim.tmp && mv out/fizzbuzz.c.eir.vim.tmp out/fizzbuzz.c.eir.vim
out/elc -vim out/addsub.c.eir > out/addsub.c.eir.vim.tmp && chmod 755 out/addsub.c.eir.vim.tmp && mv out/addsub.c.eir.vim.tmp out/addsub.c.eir.vim
out/elc -vim out/printf.c.eir > out/printf.c.eir.vim.tmp && chmod 755 out/printf.c.eir.vim.tmp && mv out/printf.c.eir.vim.tmp out/printf.c.eir.vim
out/elc -vim out/switch_range.c.eir > out/switch_range.c.eir.vim.tmp && chmod 755 out/switch_range.c.eir.vim.tmp && mv out/switch_range.c.eir.vim.tmp out/switch_range.c.eir.vim
out/elc -vim out/struct.c.eir > out/struct.c.eir.vim.tmp && chmod 755 out/struct.c.eir.vim.tmp && mv out/struct.c.eir.vim.tmp out/struct.c.eir.vim
out/elc -vim out/cmp_eq.c.eir > out/cmp_eq.c.eir.vim.tmp && chmod 755 out/cmp_eq.c.eir.vim.tmp && mv out/cmp_eq.c.eir.vim.tmp out/cmp_eq.c.eir.vim
out/elc -vim out/switch_case.c.eir > out/switch_case.c.eir.vim.tmp && chmod 755 out/switch_case.c.eir.vim.tmp && mv out/switch_case.c.eir.vim.tmp out/switch_case.c.eir.vim
out/elc -vim out/cmp_ne.c.eir > out/cmp_ne.c.eir.vim.tmp && chmod 755 out/cmp_ne.c.eir.vim.tmp && mv out/cmp_ne.c.eir.vim.tmp out/cmp_ne.c.eir.vim
out/elc -vim out/global_struct_ref.c.eir > out/global_struct_ref.c.eir.vim.tmp && chmod 755 out/global_struct_ref.c.eir.vim.tmp && mv out/global_struct_ref.c.eir.vim.tmp out/global_struct_ref.c.eir.vim
out/elc -vim out/cmp_le.c.eir > out/cmp_le.c.eir.vim.tmp && chmod 755 out/cmp_le.c.eir.vim.tmp && mv out/cmp_le.c.eir.vim.tmp out/cmp_le.c.eir.vim
out/elc -vim out/global.c.eir > out/global.c.eir.vim.tmp && chmod 755 out/global.c.eir.vim.tmp && mv out/global.c.eir.vim.tmp out/global.c.eir.vim
out/elc -vim out/field_addr.c.eir > out/field_addr.c.eir.vim.tmp && chmod 755 out/field_addr.c.eir.vim.tmp && mv out/field_addr.c.eir.vim.tmp out/field_addr.c.eir.vim
out/elc -vim out/swapcase.c.eir > out/swapcase.c.eir.vim.tmp && chmod 755 out/swapcase.c.eir.vim.tmp && mv out/swapcase.c.eir.vim.tmp out/swapcase.c.eir.vim
out/elc -vim out/nullptr.c.eir > out/nullptr.c.eir.vim.tmp && chmod 755 out/nullptr.c.eir.vim.tmp && mv out/nullptr.c.eir.vim.tmp out/nullptr.c.eir.vim
out/elc -vim out/puts.c.eir > out/puts.c.eir.vim.tmp && chmod 755 out/puts.c.eir.vim.tmp && mv out/puts.c.eir.vim.tmp out/puts.c.eir.vim
out/elc -vim out/print_int.c.eir > out/print_int.c.eir.vim.tmp && chmod 755 out/print_int.c.eir.vim.tmp && mv out/print_int.c.eir.vim.tmp out/print_int.c.eir.vim
out/elc -vim out/logic_val.c.eir > out/logic_val.c.eir.vim.tmp && chmod 755 out/logic_val.c.eir.vim.tmp && mv out/logic_val.c.eir.vim.tmp out/logic_val.c.eir.vim
out/elc -vim out/global_array.c.eir > out/global_array.c.eir.vim.tmp && chmod 755 out/global_array.c.eir.vim.tmp && mv out/global_array.c.eir.vim.tmp out/global_array.c.eir.vim
out/elc -vim out/fizzbuzz_fast.c.eir > out/fizzbuzz_fast.c.eir.vim.tmp && chmod 755 out/fizzbuzz_fast.c.eir.vim.tmp && mv out/fizzbuzz_fast.c.eir.vim.tmp out/fizzbuzz_fast.c.eir.vim
out/elc -vim out/hello.c.eir > out/hello.c.eir.vim.tmp && chmod 755 out/hello.c.eir.vim.tmp && mv out/hello.c.eir.vim.tmp out/hello.c.eir.vim
out/elc -vim out/switch_op.c.eir > out/switch_op.c.eir.vim.tmp && chmod 755 out/switch_op.c.eir.vim.tmp && mv out/switch_op.c.eir.vim.tmp out/switch_op.c.eir.vim
out/elc -vim out/24_muldiv.c.eir > out/24_muldiv.c.eir.vim.tmp && chmod 755 out/24_muldiv.c.eir.vim.tmp && mv out/24_muldiv.c.eir.vim.tmp out/24_muldiv.c.eir.vim
out/elc -vim out/func_ptr.c.eir > out/func_ptr.c.eir.vim.tmp && chmod 755 out/func_ptr.c.eir.vim.tmp && mv out/func_ptr.c.eir.vim.tmp out/func_ptr.c.eir.vim
out/elc -vim out/cmp_gt.c.eir > out/cmp_gt.c.eir.vim.tmp && chmod 755 out/cmp_gt.c.eir.vim.tmp && mv out/cmp_gt.c.eir.vim.tmp out/cmp_gt.c.eir.vim
out/elc -vim out/getchar.c.eir > out/getchar.c.eir.vim.tmp && chmod 755 out/getchar.c.eir.vim.tmp && mv out/getchar.c.eir.vim.tmp out/getchar.c.eir.vim
out/elc -vim out/8cc.in.c.eir > out/8cc.in.c.eir.vim.tmp && chmod 755 out/8cc.in.c.eir.vim.tmp && mv out/8cc.in.c.eir.vim.tmp out/8cc.in.c.eir.vim
out/elc -vim out/malloc.c.eir > out/malloc.c.eir.vim.tmp && chmod 755 out/malloc.c.eir.vim.tmp && mv out/malloc.c.eir.vim.tmp out/malloc.c.eir.vim
out/elc -vim out/cmp_ge.c.eir > out/cmp_ge.c.eir.vim.tmp && chmod 755 out/cmp_ge.c.eir.vim.tmp && mv out/cmp_ge.c.eir.vim.tmp out/cmp_ge.c.eir.vim
out/elc -vim out/increment.c.eir > out/increment.c.eir.vim.tmp && chmod 755 out/increment.c.eir.vim.tmp && mv out/increment.c.eir.vim.tmp out/increment.c.eir.vim
out/elc -vim out/24_cmp2.c.eir > out/24_cmp2.c.eir.vim.tmp && chmod 755 out/24_cmp2.c.eir.vim.tmp && mv out/24_cmp2.c.eir.vim.tmp out/24_cmp2.c.eir.vim
out/elc -vim out/putchar.c.eir > out/putchar.c.eir.vim.tmp && chmod 755 out/putchar.c.eir.vim.tmp && mv out/putchar.c.eir.vim.tmp out/putchar.c.eir.vim
out/elc -vim out/eof.c.eir > out/eof.c.eir.vim.tmp && chmod 755 out/eof.c.eir.vim.tmp && mv out/eof.c.eir.vim.tmp out/eof.c.eir.vim
out/elc -vim out/24_cmp.c.eir > out/24_cmp.c.eir.vim.tmp && chmod 755 out/24_cmp.c.eir.vim.tmp && mv out/24_cmp.c.eir.vim.tmp out/24_cmp.c.eir.vim
out/elc -vim out/lisp.c.eir > out/lisp.c.eir.vim.tmp && chmod 755 out/lisp.c.eir.vim.tmp && mv out/lisp.c.eir.vim.tmp out/lisp.c.eir.vim
out/elc -vim out/func.c.eir > out/func.c.eir.vim.tmp && chmod 755 out/func.c.eir.vim.tmp && mv out/func.c.eir.vim.tmp out/func.c.eir.vim
out/elc -vim out/muldiv.c.eir > out/muldiv.c.eir.vim.tmp && chmod 755 out/muldiv.c.eir.vim.tmp && mv out/muldiv.c.eir.vim.tmp out/muldiv.c.eir.vim
out/elc -vim out/array.c.eir > out/array.c.eir.vim.tmp && chmod 755 out/array.c.eir.vim.tmp && mv out/array.c.eir.vim.tmp out/array.c.eir.vim
out/elc -vim out/loop.c.eir > out/loop.c.eir.vim.tmp && chmod 755 out/loop.c.eir.vim.tmp && mv out/loop.c.eir.vim.tmp out/loop.c.eir.vim
out/elc -vim out/copy_struct.c.eir > out/copy_struct.c.eir.vim.tmp && chmod 755 out/copy_struct.c.eir.vim.tmp && mv out/copy_struct.c.eir.vim.tmp out/copy_struct.c.eir.vim
out/elc -vim out/cmp_lt.c.eir > out/cmp_lt.c.eir.vim.tmp && chmod 755 out/cmp_lt.c.eir.vim.tmp && mv out/cmp_lt.c.eir.vim.tmp out/cmp_lt.c.eir.vim
out/elc -vim out/8cc.c.eir > out/8cc.c.eir.vim.tmp && chmod 755 out/8cc.c.eir.vim.tmp && mv out/8cc.c.eir.vim.tmp out/8cc.c.eir.vim
out/elc -vim out/elc.c.eir > out/elc.c.eir.vim.tmp && chmod 755 out/elc.c.eir.vim.tmp && mv out/elc.c.eir.vim.tmp out/elc.c.eir.vim
out/elc -vim out/dump_ir.c.eir > out/dump_ir.c.eir.vim.tmp && chmod 755 out/dump_ir.c.eir.vim.tmp && mv out/dump_ir.c.eir.vim.tmp out/dump_ir.c.eir.vim
out/elc -vim out/eli.c.eir > out/eli.c.eir.vim.tmp && chmod 755 out/eli.c.eir.vim.tmp && mv out/eli.c.eir.vim.tmp out/eli.c.eir.vim
./runtest.sh out/00exit.eir.vim.out tools/runvim.sh out/00exit.eir.vim
./runtest.sh out/01putc.eir.vim.out tools/runvim.sh out/01putc.eir.vim
./runtest.sh out/02mov.eir.vim.out tools/runvim.sh out/02mov.eir.vim
./runtest.sh out/03mov_reg.eir.vim.out tools/runvim.sh out/03mov_reg.eir.vim
./runtest.sh out/04getc.eir.vim.out tools/runvim.sh out/04getc.eir.vim
./runtest.sh out/05regjmp.eir.vim.out tools/runvim.sh out/05regjmp.eir.vim
./runtest.sh out/06mem.eir.vim.out tools/runvim.sh out/06mem.eir.vim
./runtest.sh out/07mem.eir.vim.out tools/runvim.sh out/07mem.eir.vim
./runtest.sh out/08data.eir.vim.out tools/runvim.sh out/08data.eir.vim
./runtest.sh out/add_self.eir.vim.out tools/runvim.sh out/add_self.eir.vim
./runtest.sh out/basic.eir.vim.out tools/runvim.sh out/basic.eir.vim
./runtest.sh out/bug_cmp.eir.vim.out tools/runvim.sh out/bug_cmp.eir.vim
./runtest.sh out/echo.eir.vim.out tools/runvim.sh out/echo.eir.vim
./runtest.sh out/isprint.eir.vim.out tools/runvim.sh out/isprint.eir.vim
./runtest.sh out/neg.eir.vim.out tools/runvim.sh out/neg.eir.vim
./runtest.sh out/sub.eir.vim.out tools/runvim.sh out/sub.eir.vim
./runtest.sh out/sub_bug.eir.vim.out tools/runvim.sh out/sub_bug.eir.vim
./runtest.sh out/cmps.eir.vim.out tools/runvim.sh out/cmps.eir.vim
./runtest.sh out/jmps.eir.vim.out tools/runvim.sh out/jmps.eir.vim
./runtest.sh out/24_mem.eir.vim.out tools/runvim.sh out/24_mem.eir.vim
./runtest.sh out/bm_mov.eir.vim.out tools/runvim.sh out/bm_mov.eir.vim
./runtest.sh out/func2.c.eir.vim.out tools/runvim.sh out/func2.c.eir.vim
./runtest.sh out/fizzbuzz.c.eir.vim.out tools/runvim.sh out/fizzbuzz.c.eir.vim
./runtest.sh out/addsub.c.eir.vim.out tools/runvim.sh out/addsub.c.eir.vim
./runtest.sh out/printf.c.eir.vim.out tools/runvim.sh out/printf.c.eir.vim
./runtest.sh out/switch_range.c.eir.vim.out tools/runvim.sh out/switch_range.c.eir.vim
./runtest.sh out/struct.c.eir.vim.out tools/runvim.sh out/struct.c.eir.vim
./runtest.sh out/cmp_eq.c.eir.vim.out tools/runvim.sh out/cmp_eq.c.eir.vim
./runtest.sh out/switch_case.c.eir.vim.out tools/runvim.sh out/switch_case.c.eir.vim
./runtest.sh out/cmp_ne.c.eir.vim.out tools/runvim.sh out/cmp_ne.c.eir.vim
./runtest.sh out/global_struct_ref.c.eir.vim.out tools/runvim.sh out/global_struct_ref.c.eir.vim
./runtest.sh out/cmp_le.c.eir.vim.out tools/runvim.sh out/cmp_le.c.eir.vim
./runtest.sh out/global.c.eir.vim.out tools/runvim.sh out/global.c.eir.vim
./runtest.sh out/field_addr.c.eir.vim.out tools/runvim.sh out/field_addr.c.eir.vim
./runtest.sh out/swapcase.c.eir.vim.out tools/runvim.sh out/swapcase.c.eir.vim
./runtest.sh out/nullptr.c.eir.vim.out tools/runvim.sh out/nullptr.c.eir.vim
./runtest.sh out/puts.c.eir.vim.out tools/runvim.sh out/puts.c.eir.vim
./runtest.sh out/print_int.c.eir.vim.out tools/runvim.sh out/print_int.c.eir.vim
./runtest.sh out/logic_val.c.eir.vim.out tools/runvim.sh out/logic_val.c.eir.vim
./runtest.sh out/global_array.c.eir.vim.out tools/runvim.sh out/global_array.c.eir.vim
./runtest.sh out/fizzbuzz_fast.c.eir.vim.out tools/runvim.sh out/fizzbuzz_fast.c.eir.vim
./runtest.sh out/hello.c.eir.vim.out tools/runvim.sh out/hello.c.eir.vim
./runtest.sh out/switch_op.c.eir.vim.out tools/runvim.sh out/switch_op.c.eir.vim
./runtest.sh out/24_muldiv.c.eir.vim.out tools/runvim.sh out/24_muldiv.c.eir.vim
./runtest.sh out/func_ptr.c.eir.vim.out tools/runvim.sh out/func_ptr.c.eir.vim
./runtest.sh out/cmp_gt.c.eir.vim.out tools/runvim.sh out/cmp_gt.c.eir.vim
./runtest.sh out/getchar.c.eir.vim.out tools/runvim.sh out/getchar.c.eir.vim
./runtest.sh out/8cc.in.c.eir.vim.out tools/runvim.sh out/8cc.in.c.eir.vim
./runtest.sh out/malloc.c.eir.vim.out tools/runvim.sh out/malloc.c.eir.vim
./runtest.sh out/cmp_ge.c.eir.vim.out tools/runvim.sh out/cmp_ge.c.eir.vim
./runtest.sh out/increment.c.eir.vim.out tools/runvim.sh out/increment.c.eir.vim
./runtest.sh out/24_cmp2.c.eir.vim.out tools/runvim.sh out/24_cmp2.c.eir.vim
./runtest.sh out/putchar.c.eir.vim.out tools/runvim.sh out/putchar.c.eir.vim
./runtest.sh out/eof.c.eir.vim.out tools/runvim.sh out/eof.c.eir.vim
./runtest.sh out/24_cmp.c.eir.vim.out tools/runvim.sh out/24_cmp.c.eir.vim
./runtest.sh out/lisp.c.eir.vim.out tools/runvim.sh out/lisp.c.eir.vim
./runtest.sh out/func.c.eir.vim.out tools/runvim.sh out/func.c.eir.vim
./runtest.sh out/muldiv.c.eir.vim.out tools/runvim.sh out/muldiv.c.eir.vim
./runtest.sh out/array.c.eir.vim.out tools/runvim.sh out/array.c.eir.vim
./runtest.sh out/loop.c.eir.vim.out tools/runvim.sh out/loop.c.eir.vim
./runtest.sh out/copy_struct.c.eir.vim.out tools/runvim.sh out/copy_struct.c.eir.vim
./runtest.sh out/cmp_lt.c.eir.vim.out tools/runvim.sh out/cmp_lt.c.eir.vim
./runtest.sh out/8cc.c.eir.vim.out tools/runvim.sh out/8cc.c.eir.vim
./runtest.sh out/elc.c.eir.vim.out tools/runvim.sh out/elc.c.eir.vim
./runtest.sh out/dump_ir.c.eir.vim.out tools/runvim.sh out/dump_ir.c.eir.vim
./runtest.sh out/eli.c.eir.vim.out tools/runvim.sh out/eli.c.eir.vim
(diff -u out/00exit.eir.out out/00exit.eir.vim.out > out/00exit.eir.vim.out.diff.tmp && mv out/00exit.eir.vim.out.diff.tmp out/00exit.eir.vim.out.diff) || (cat out/00exit.eir.vim.out.diff.tmp ; false)
(diff -u out/01putc.eir.out out/01putc.eir.vim.out > out/01putc.eir.vim.out.diff.tmp && mv out/01putc.eir.vim.out.diff.tmp out/01putc.eir.vim.out.diff) || (cat out/01putc.eir.vim.out.diff.tmp ; false)
(diff -u out/02mov.eir.out out/02mov.eir.vim.out > out/02mov.eir.vim.out.diff.tmp && mv out/02mov.eir.vim.out.diff.tmp out/02mov.eir.vim.out.diff) || (cat out/02mov.eir.vim.out.diff.tmp ; false)
(diff -u out/03mov_reg.eir.out out/03mov_reg.eir.vim.out > out/03mov_reg.eir.vim.out.diff.tmp && mv out/03mov_reg.eir.vim.out.diff.tmp out/03mov_reg.eir.vim.out.diff) || (cat out/03mov_reg.eir.vim.out.diff.tmp ; false)
(diff -u out/04getc.eir.out out/04getc.eir.vim.out > out/04getc.eir.vim.out.diff.tmp && mv out/04getc.eir.vim.out.diff.tmp out/04getc.eir.vim.out.diff) || (cat out/04getc.eir.vim.out.diff.tmp ; false)
(diff -u out/05regjmp.eir.out out/05regjmp.eir.vim.out > out/05regjmp.eir.vim.out.diff.tmp && mv out/05regjmp.eir.vim.out.diff.tmp out/05regjmp.eir.vim.out.diff) || (cat out/05regjmp.eir.vim.out.diff.tmp ; false)
(diff -u out/06mem.eir.out out/06mem.eir.vim.out > out/06mem.eir.vim.out.diff.tmp && mv out/06mem.eir.vim.out.diff.tmp out/06mem.eir.vim.out.diff) || (cat out/06mem.eir.vim.out.diff.tmp ; false)
(diff -u out/07mem.eir.out out/07mem.eir.vim.out > out/07mem.eir.vim.out.diff.tmp && mv out/07mem.eir.vim.out.diff.tmp out/07mem.eir.vim.out.diff) || (cat out/07mem.eir.vim.out.diff.tmp ; false)
(diff -u out/08data.eir.out out/08data.eir.vim.out > out/08data.eir.vim.out.diff.tmp && mv out/08data.eir.vim.out.diff.tmp out/08data.eir.vim.out.diff) || (cat out/08data.eir.vim.out.diff.tmp ; false)
(diff -u out/add_self.eir.out out/add_self.eir.vim.out > out/add_self.eir.vim.out.diff.tmp && mv out/add_self.eir.vim.out.diff.tmp out/add_self.eir.vim.out.diff) || (cat out/add_self.eir.vim.out.diff.tmp ; false)
(diff -u out/basic.eir.out out/basic.eir.vim.out > out/basic.eir.vim.out.diff.tmp && mv out/basic.eir.vim.out.diff.tmp out/basic.eir.vim.out.diff) || (cat out/basic.eir.vim.out.diff.tmp ; false)
(diff -u out/bug_cmp.eir.out out/bug_cmp.eir.vim.out > out/bug_cmp.eir.vim.out.diff.tmp && mv out/bug_cmp.eir.vim.out.diff.tmp out/bug_cmp.eir.vim.out.diff) || (cat out/bug_cmp.eir.vim.out.diff.tmp ; false)
(diff -u out/echo.eir.out out/echo.eir.vim.out > out/echo.eir.vim.out.diff.tmp && mv out/echo.eir.vim.out.diff.tmp out/echo.eir.vim.out.diff) || (cat out/echo.eir.vim.out.diff.tmp ; false)
(diff -u out/isprint.eir.out out/isprint.eir.vim.out > out/isprint.eir.vim.out.diff.tmp && mv out/isprint.eir.vim.out.diff.tmp out/isprint.eir.vim.out.diff) || (cat out/isprint.eir.vim.out.diff.tmp ; false)
(diff -u out/neg.eir.out out/neg.eir.vim.out > out/neg.eir.vim.out.diff.tmp && mv out/neg.eir.vim.out.diff.tmp out/neg.eir.vim.out.diff) || (cat out/neg.eir.vim.out.diff.tmp ; false)
(diff -u out/sub.eir.out out/sub.eir.vim.out > out/sub.eir.vim.out.diff.tmp && mv out/sub.eir.vim.out.diff.tmp out/sub.eir.vim.out.diff) || (cat out/sub.eir.vim.out.diff.tmp ; false)
(diff -u out/sub_bug.eir.out out/sub_bug.eir.vim.out > out/sub_bug.eir.vim.out.diff.tmp && mv out/sub_bug.eir.vim.out.diff.tmp out/sub_bug.eir.vim.out.diff) || (cat out/sub_bug.eir.vim.out.diff.tmp ; false)
(diff -u out/cmps.eir.out out/cmps.eir.vim.out > out/cmps.eir.vim.out.diff.tmp && mv out/cmps.eir.vim.out.diff.tmp out/cmps.eir.vim.out.diff) || (cat out/cmps.eir.vim.out.diff.tmp ; false)
(diff -u out/jmps.eir.out out/jmps.eir.vim.out > out/jmps.eir.vim.out.diff.tmp && mv out/jmps.eir.vim.out.diff.tmp out/jmps.eir.vim.out.diff) || (cat out/jmps.eir.vim.out.diff.tmp ; false)
(diff -u out/24_mem.eir.out out/24_mem.eir.vim.out > out/24_mem.eir.vim.out.diff.tmp && mv out/24_mem.eir.vim.out.diff.tmp out/24_mem.eir.vim.out.diff) || (cat out/24_mem.eir.vim.out.diff.tmp ; false)
(diff -u out/bm_mov.eir.out out/bm_mov.eir.vim.out > out/bm_mov.eir.vim.out.diff.tmp && mv out/bm_mov.eir.vim.out.diff.tmp out/bm_mov.eir.vim.out.diff) || (cat out/bm_mov.eir.vim.out.diff.tmp ; false)
(diff -u out/func2.c.eir.out out/func2.c.eir.vim.out > out/func2.c.eir.vim.out.diff.tmp && mv out/func2.c.eir.vim.out.diff.tmp out/func2.c.eir.vim.out.diff) || (cat out/func2.c.eir.vim.out.diff.tmp ; false)
(diff -u out/fizzbuzz.c.eir.out out/fizzbuzz.c.eir.vim.out > out/fizzbuzz.c.eir.vim.out.diff.tmp && mv out/fizzbuzz.c.eir.vim.out.diff.tmp out/fizzbuzz.c.eir.vim.out.diff) || (cat out/fizzbuzz.c.eir.vim.out.diff.tmp ; false)
(diff -u out/addsub.c.eir.out out/addsub.c.eir.vim.out > out/addsub.c.eir.vim.out.diff.tmp && mv out/addsub.c.eir.vim.out.diff.tmp out/addsub.c.eir.vim.out.diff) || (cat out/addsub.c.eir.vim.out.diff.tmp ; false)
(diff -u out/printf.c.eir.out out/printf.c.eir.vim.out > out/printf.c.eir.vim.out.diff.tmp && mv out/printf.c.eir.vim.out.diff.tmp out/printf.c.eir.vim.out.diff) || (cat out/printf.c.eir.vim.out.diff.tmp ; false)
(diff -u out/switch_range.c.eir.out out/switch_range.c.eir.vim.out > out/switch_range.c.eir.vim.out.diff.tmp && mv out/switch_range.c.eir.vim.out.diff.tmp out/switch_range.c.eir.vim.out.diff) || (cat out/switch_range.c.eir.vim.out.diff.tmp ; false)
(diff -u out/struct.c.eir.out out/struct.c.eir.vim.out > out/struct.c.eir.vim.out.diff.tmp && mv out/struct.c.eir.vim.out.diff.tmp out/struct.c.eir.vim.out.diff) || (cat out/struct.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_eq.c.eir.out out/cmp_eq.c.eir.vim.out > out/cmp_eq.c.eir.vim.out.diff.tmp && mv out/cmp_eq.c.eir.vim.out.diff.tmp out/cmp_eq.c.eir.vim.out.diff) || (cat out/cmp_eq.c.eir.vim.out.diff.tmp ; false)
(diff -u out/switch_case.c.eir.out out/switch_case.c.eir.vim.out > out/switch_case.c.eir.vim.out.diff.tmp && mv out/switch_case.c.eir.vim.out.diff.tmp out/switch_case.c.eir.vim.out.diff) || (cat out/switch_case.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_ne.c.eir.out out/cmp_ne.c.eir.vim.out > out/cmp_ne.c.eir.vim.out.diff.tmp && mv out/cmp_ne.c.eir.vim.out.diff.tmp out/cmp_ne.c.eir.vim.out.diff) || (cat out/cmp_ne.c.eir.vim.out.diff.tmp ; false)
(diff -u out/global_struct_ref.c.eir.out out/global_struct_ref.c.eir.vim.out > out/global_struct_ref.c.eir.vim.out.diff.tmp && mv out/global_struct_ref.c.eir.vim.out.diff.tmp out/global_struct_ref.c.eir.vim.out.diff) || (cat out/global_struct_ref.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_le.c.eir.out out/cmp_le.c.eir.vim.out > out/cmp_le.c.eir.vim.out.diff.tmp && mv out/cmp_le.c.eir.vim.out.diff.tmp out/cmp_le.c.eir.vim.out.diff) || (cat out/cmp_le.c.eir.vim.out.diff.tmp ; false)
(diff -u out/global.c.eir.out out/global.c.eir.vim.out > out/global.c.eir.vim.out.diff.tmp && mv out/global.c.eir.vim.out.diff.tmp out/global.c.eir.vim.out.diff) || (cat out/global.c.eir.vim.out.diff.tmp ; false)
(diff -u out/field_addr.c.eir.out out/field_addr.c.eir.vim.out > out/field_addr.c.eir.vim.out.diff.tmp && mv out/field_addr.c.eir.vim.out.diff.tmp out/field_addr.c.eir.vim.out.diff) || (cat out/field_addr.c.eir.vim.out.diff.tmp ; false)
(diff -u out/swapcase.c.eir.out out/swapcase.c.eir.vim.out > out/swapcase.c.eir.vim.out.diff.tmp && mv out/swapcase.c.eir.vim.out.diff.tmp out/swapcase.c.eir.vim.out.diff) || (cat out/swapcase.c.eir.vim.out.diff.tmp ; false)
(diff -u out/nullptr.c.eir.out out/nullptr.c.eir.vim.out > out/nullptr.c.eir.vim.out.diff.tmp && mv out/nullptr.c.eir.vim.out.diff.tmp out/nullptr.c.eir.vim.out.diff) || (cat out/nullptr.c.eir.vim.out.diff.tmp ; false)
(diff -u out/puts.c.eir.out out/puts.c.eir.vim.out > out/puts.c.eir.vim.out.diff.tmp && mv out/puts.c.eir.vim.out.diff.tmp out/puts.c.eir.vim.out.diff) || (cat out/puts.c.eir.vim.out.diff.tmp ; false)
(diff -u out/print_int.c.eir.out out/print_int.c.eir.vim.out > out/print_int.c.eir.vim.out.diff.tmp && mv out/print_int.c.eir.vim.out.diff.tmp out/print_int.c.eir.vim.out.diff) || (cat out/print_int.c.eir.vim.out.diff.tmp ; false)
(diff -u out/logic_val.c.eir.out out/logic_val.c.eir.vim.out > out/logic_val.c.eir.vim.out.diff.tmp && mv out/logic_val.c.eir.vim.out.diff.tmp out/logic_val.c.eir.vim.out.diff) || (cat out/logic_val.c.eir.vim.out.diff.tmp ; false)
(diff -u out/global_array.c.eir.out out/global_array.c.eir.vim.out > out/global_array.c.eir.vim.out.diff.tmp && mv out/global_array.c.eir.vim.out.diff.tmp out/global_array.c.eir.vim.out.diff) || (cat out/global_array.c.eir.vim.out.diff.tmp ; false)
(diff -u out/fizzbuzz_fast.c.eir.out out/fizzbuzz_fast.c.eir.vim.out > out/fizzbuzz_fast.c.eir.vim.out.diff.tmp && mv out/fizzbuzz_fast.c.eir.vim.out.diff.tmp out/fizzbuzz_fast.c.eir.vim.out.diff) || (cat out/fizzbuzz_fast.c.eir.vim.out.diff.tmp ; false)
(diff -u out/hello.c.eir.out out/hello.c.eir.vim.out > out/hello.c.eir.vim.out.diff.tmp && mv out/hello.c.eir.vim.out.diff.tmp out/hello.c.eir.vim.out.diff) || (cat out/hello.c.eir.vim.out.diff.tmp ; false)
(diff -u out/switch_op.c.eir.out out/switch_op.c.eir.vim.out > out/switch_op.c.eir.vim.out.diff.tmp && mv out/switch_op.c.eir.vim.out.diff.tmp out/switch_op.c.eir.vim.out.diff) || (cat out/switch_op.c.eir.vim.out.diff.tmp ; false)
(diff -u out/24_muldiv.c.eir.out out/24_muldiv.c.eir.vim.out > out/24_muldiv.c.eir.vim.out.diff.tmp && mv out/24_muldiv.c.eir.vim.out.diff.tmp out/24_muldiv.c.eir.vim.out.diff) || (cat out/24_muldiv.c.eir.vim.out.diff.tmp ; false)
(diff -u out/func_ptr.c.eir.out out/func_ptr.c.eir.vim.out > out/func_ptr.c.eir.vim.out.diff.tmp && mv out/func_ptr.c.eir.vim.out.diff.tmp out/func_ptr.c.eir.vim.out.diff) || (cat out/func_ptr.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_gt.c.eir.out out/cmp_gt.c.eir.vim.out > out/cmp_gt.c.eir.vim.out.diff.tmp && mv out/cmp_gt.c.eir.vim.out.diff.tmp out/cmp_gt.c.eir.vim.out.diff) || (cat out/cmp_gt.c.eir.vim.out.diff.tmp ; false)
(diff -u out/getchar.c.eir.out out/getchar.c.eir.vim.out > out/getchar.c.eir.vim.out.diff.tmp && mv out/getchar.c.eir.vim.out.diff.tmp out/getchar.c.eir.vim.out.diff) || (cat out/getchar.c.eir.vim.out.diff.tmp ; false)
(diff -u out/8cc.in.c.eir.out out/8cc.in.c.eir.vim.out > out/8cc.in.c.eir.vim.out.diff.tmp && mv out/8cc.in.c.eir.vim.out.diff.tmp out/8cc.in.c.eir.vim.out.diff) || (cat out/8cc.in.c.eir.vim.out.diff.tmp ; false)
(diff -u out/malloc.c.eir.out out/malloc.c.eir.vim.out > out/malloc.c.eir.vim.out.diff.tmp && mv out/malloc.c.eir.vim.out.diff.tmp out/malloc.c.eir.vim.out.diff) || (cat out/malloc.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_ge.c.eir.out out/cmp_ge.c.eir.vim.out > out/cmp_ge.c.eir.vim.out.diff.tmp && mv out/cmp_ge.c.eir.vim.out.diff.tmp out/cmp_ge.c.eir.vim.out.diff) || (cat out/cmp_ge.c.eir.vim.out.diff.tmp ; false)
(diff -u out/increment.c.eir.out out/increment.c.eir.vim.out > out/increment.c.eir.vim.out.diff.tmp && mv out/increment.c.eir.vim.out.diff.tmp out/increment.c.eir.vim.out.diff) || (cat out/increment.c.eir.vim.out.diff.tmp ; false)
(diff -u out/24_cmp2.c.eir.out out/24_cmp2.c.eir.vim.out > out/24_cmp2.c.eir.vim.out.diff.tmp && mv out/24_cmp2.c.eir.vim.out.diff.tmp out/24_cmp2.c.eir.vim.out.diff) || (cat out/24_cmp2.c.eir.vim.out.diff.tmp ; false)
(diff -u out/putchar.c.eir.out out/putchar.c.eir.vim.out > out/putchar.c.eir.vim.out.diff.tmp && mv out/putchar.c.eir.vim.out.diff.tmp out/putchar.c.eir.vim.out.diff) || (cat out/putchar.c.eir.vim.out.diff.tmp ; false)
(diff -u out/eof.c.eir.out out/eof.c.eir.vim.out > out/eof.c.eir.vim.out.diff.tmp && mv out/eof.c.eir.vim.out.diff.tmp out/eof.c.eir.vim.out.diff) || (cat out/eof.c.eir.vim.out.diff.tmp ; false)
(diff -u out/24_cmp.c.eir.out out/24_cmp.c.eir.vim.out > out/24_cmp.c.eir.vim.out.diff.tmp && mv out/24_cmp.c.eir.vim.out.diff.tmp out/24_cmp.c.eir.vim.out.diff) || (cat out/24_cmp.c.eir.vim.out.diff.tmp ; false)
(diff -u out/lisp.c.eir.out out/lisp.c.eir.vim.out > out/lisp.c.eir.vim.out.diff.tmp && mv out/lisp.c.eir.vim.out.diff.tmp out/lisp.c.eir.vim.out.diff) || (cat out/lisp.c.eir.vim.out.diff.tmp ; false)
(diff -u out/func.c.eir.out out/func.c.eir.vim.out > out/func.c.eir.vim.out.diff.tmp && mv out/func.c.eir.vim.out.diff.tmp out/func.c.eir.vim.out.diff) || (cat out/func.c.eir.vim.out.diff.tmp ; false)
(diff -u out/muldiv.c.eir.out out/muldiv.c.eir.vim.out > out/muldiv.c.eir.vim.out.diff.tmp && mv out/muldiv.c.eir.vim.out.diff.tmp out/muldiv.c.eir.vim.out.diff) || (cat out/muldiv.c.eir.vim.out.diff.tmp ; false)
(diff -u out/array.c.eir.out out/array.c.eir.vim.out > out/array.c.eir.vim.out.diff.tmp && mv out/array.c.eir.vim.out.diff.tmp out/array.c.eir.vim.out.diff) || (cat out/array.c.eir.vim.out.diff.tmp ; false)
(diff -u out/loop.c.eir.out out/loop.c.eir.vim.out > out/loop.c.eir.vim.out.diff.tmp && mv out/loop.c.eir.vim.out.diff.tmp out/loop.c.eir.vim.out.diff) || (cat out/loop.c.eir.vim.out.diff.tmp ; false)
(diff -u out/copy_struct.c.eir.out out/copy_struct.c.eir.vim.out > out/copy_struct.c.eir.vim.out.diff.tmp && mv out/copy_struct.c.eir.vim.out.diff.tmp out/copy_struct.c.eir.vim.out.diff) || (cat out/copy_struct.c.eir.vim.out.diff.tmp ; false)
(diff -u out/cmp_lt.c.eir.out out/cmp_lt.c.eir.vim.out > out/cmp_lt.c.eir.vim.out.diff.tmp && mv out/cmp_lt.c.eir.vim.out.diff.tmp out/cmp_lt.c.eir.vim.out.diff) || (cat out/cmp_lt.c.eir.vim.out.diff.tmp ; false)
(diff -u out/8cc.c.eir.out out/8cc.c.eir.vim.out > out/8cc.c.eir.vim.out.diff.tmp && mv out/8cc.c.eir.vim.out.diff.tmp out/8cc.c.eir.vim.out.diff) || (cat out/8cc.c.eir.vim.out.diff.tmp ; false)
(diff -u out/elc.c.eir.out out/elc.c.eir.vim.out > out/elc.c.eir.vim.out.diff.tmp && mv out/elc.c.eir.vim.out.diff.tmp out/elc.c.eir.vim.out.diff) || (cat out/elc.c.eir.vim.out.diff.tmp ; false)
(diff -u out/dump_ir.c.eir.out out/dump_ir.c.eir.vim.out > out/dump_ir.c.eir.vim.out.diff.tmp && mv out/dump_ir.c.eir.vim.out.diff.tmp out/dump_ir.c.eir.vim.out.diff) || (cat out/dump_ir.c.eir.vim.out.diff.tmp ; false)
(diff -u out/eli.c.eir.out out/eli.c.eir.vim.out > out/eli.c.eir.vim.out.diff.tmp && mv out/eli.c.eir.vim.out.diff.tmp out/eli.c.eir.vim.out.diff) || (cat out/eli.c.eir.vim.out.diff.tmp ; false)
out/elc -x86 out/elc.c.eir > out/elc.c.eir.x86.tmp && chmod 755 out/elc.c.eir.x86.tmp && mv out/elc.c.eir.x86.tmp out/elc.c.eir.x86
(echo vim && cat out/00exit.eir) | out/elc.c.eir.x86 > out/00exit.eir.elc.vim.tmp && mv out/00exit.eir.elc.vim.tmp out/00exit.eir.elc.vim
(echo vim && cat out/01putc.eir) | out/elc.c.eir.x86 > out/01putc.eir.elc.vim.tmp && mv out/01putc.eir.elc.vim.tmp out/01putc.eir.elc.vim
(echo vim && cat out/02mov.eir) | out/elc.c.eir.x86 > out/02mov.eir.elc.vim.tmp && mv out/02mov.eir.elc.vim.tmp out/02mov.eir.elc.vim
(echo vim && cat out/03mov_reg.eir) | out/elc.c.eir.x86 > out/03mov_reg.eir.elc.vim.tmp && mv out/03mov_reg.eir.elc.vim.tmp out/03mov_reg.eir.elc.vim
(echo vim && cat out/04getc.eir) | out/elc.c.eir.x86 > out/04getc.eir.elc.vim.tmp && mv out/04getc.eir.elc.vim.tmp out/04getc.eir.elc.vim
(echo vim && cat out/05regjmp.eir) | out/elc.c.eir.x86 > out/05regjmp.eir.elc.vim.tmp && mv out/05regjmp.eir.elc.vim.tmp out/05regjmp.eir.elc.vim
(echo vim && cat out/06mem.eir) | out/elc.c.eir.x86 > out/06mem.eir.elc.vim.tmp && mv out/06mem.eir.elc.vim.tmp out/06mem.eir.elc.vim
(echo vim && cat out/07mem.eir) | out/elc.c.eir.x86 > out/07mem.eir.elc.vim.tmp && mv out/07mem.eir.elc.vim.tmp out/07mem.eir.elc.vim
(echo vim && cat out/08data.eir) | out/elc.c.eir.x86 > out/08data.eir.elc.vim.tmp && mv out/08data.eir.elc.vim.tmp out/08data.eir.elc.vim
(echo vim && cat out/add_self.eir) | out/elc.c.eir.x86 > out/add_self.eir.elc.vim.tmp && mv out/add_self.eir.elc.vim.tmp out/add_self.eir.elc.vim
(echo vim && cat out/basic.eir) | out/elc.c.eir.x86 > out/basic.eir.elc.vim.tmp && mv out/basic.eir.elc.vim.tmp out/basic.eir.elc.vim
(echo vim && cat out/bug_cmp.eir) | out/elc.c.eir.x86 > out/bug_cmp.eir.elc.vim.tmp && mv out/bug_cmp.eir.elc.vim.tmp out/bug_cmp.eir.elc.vim
(echo vim && cat out/echo.eir) | out/elc.c.eir.x86 > out/echo.eir.elc.vim.tmp && mv out/echo.eir.elc.vim.tmp out/echo.eir.elc.vim
(echo vim && cat out/isprint.eir) | out/elc.c.eir.x86 > out/isprint.eir.elc.vim.tmp && mv out/isprint.eir.elc.vim.tmp out/isprint.eir.elc.vim
(echo vim && cat out/neg.eir) | out/elc.c.eir.x86 > out/neg.eir.elc.vim.tmp && mv out/neg.eir.elc.vim.tmp out/neg.eir.elc.vim
(echo vim && cat out/sub.eir) | out/elc.c.eir.x86 > out/sub.eir.elc.vim.tmp && mv out/sub.eir.elc.vim.tmp out/sub.eir.elc.vim
(echo vim && cat out/sub_bug.eir) | out/elc.c.eir.x86 > out/sub_bug.eir.elc.vim.tmp && mv out/sub_bug.eir.elc.vim.tmp out/sub_bug.eir.elc.vim
(echo vim && cat out/cmps.eir) | out/elc.c.eir.x86 > out/cmps.eir.elc.vim.tmp && mv out/cmps.eir.elc.vim.tmp out/cmps.eir.elc.vim
(echo vim && cat out/jmps.eir) | out/elc.c.eir.x86 > out/jmps.eir.elc.vim.tmp && mv out/jmps.eir.elc.vim.tmp out/jmps.eir.elc.vim
(echo vim && cat out/24_mem.eir) | out/elc.c.eir.x86 > out/24_mem.eir.elc.vim.tmp && mv out/24_mem.eir.elc.vim.tmp out/24_mem.eir.elc.vim
(echo vim && cat out/bm_mov.eir) | out/elc.c.eir.x86 > out/bm_mov.eir.elc.vim.tmp && mv out/bm_mov.eir.elc.vim.tmp out/bm_mov.eir.elc.vim
(echo vim && cat out/func2.c.eir) | out/elc.c.eir.x86 > out/func2.c.eir.elc.vim.tmp && mv out/func2.c.eir.elc.vim.tmp out/func2.c.eir.elc.vim
(echo vim && cat out/fizzbuzz.c.eir) | out/elc.c.eir.x86 > out/fizzbuzz.c.eir.elc.vim.tmp && mv out/fizzbuzz.c.eir.elc.vim.tmp out/fizzbuzz.c.eir.elc.vim
(echo vim && cat out/addsub.c.eir) | out/elc.c.eir.x86 > out/addsub.c.eir.elc.vim.tmp && mv out/addsub.c.eir.elc.vim.tmp out/addsub.c.eir.elc.vim
(echo vim && cat out/printf.c.eir) | out/elc.c.eir.x86 > out/printf.c.eir.elc.vim.tmp && mv out/printf.c.eir.elc.vim.tmp out/printf.c.eir.elc.vim
(echo vim && cat out/switch_range.c.eir) | out/elc.c.eir.x86 > out/switch_range.c.eir.elc.vim.tmp && mv out/switch_range.c.eir.elc.vim.tmp out/switch_range.c.eir.elc.vim
(echo vim && cat out/struct.c.eir) | out/elc.c.eir.x86 > out/struct.c.eir.elc.vim.tmp && mv out/struct.c.eir.elc.vim.tmp out/struct.c.eir.elc.vim
(echo vim && cat out/cmp_eq.c.eir) | out/elc.c.eir.x86 > out/cmp_eq.c.eir.elc.vim.tmp && mv out/cmp_eq.c.eir.elc.vim.tmp out/cmp_eq.c.eir.elc.vim
(echo vim && cat out/switch_case.c.eir) | out/elc.c.eir.x86 > out/switch_case.c.eir.elc.vim.tmp && mv out/switch_case.c.eir.elc.vim.tmp out/switch_case.c.eir.elc.vim
(echo vim && cat out/cmp_ne.c.eir) | out/elc.c.eir.x86 > out/cmp_ne.c.eir.elc.vim.tmp && mv out/cmp_ne.c.eir.elc.vim.tmp out/cmp_ne.c.eir.elc.vim
(echo vim && cat out/global_struct_ref.c.eir) | out/elc.c.eir.x86 > out/global_struct_ref.c.eir.elc.vim.tmp && mv out/global_struct_ref.c.eir.elc.vim.tmp out/global_struct_ref.c.eir.elc.vim
(echo vim && cat out/cmp_le.c.eir) | out/elc.c.eir.x86 > out/cmp_le.c.eir.elc.vim.tmp && mv out/cmp_le.c.eir.elc.vim.tmp out/cmp_le.c.eir.elc.vim
(echo vim && cat out/global.c.eir) | out/elc.c.eir.x86 > out/global.c.eir.elc.vim.tmp && mv out/global.c.eir.elc.vim.tmp out/global.c.eir.elc.vim
(echo vim && cat out/field_addr.c.eir) | out/elc.c.eir.x86 > out/field_addr.c.eir.elc.vim.tmp && mv out/field_addr.c.eir.elc.vim.tmp out/field_addr.c.eir.elc.vim
(echo vim && cat out/swapcase.c.eir) | out/elc.c.eir.x86 > out/swapcase.c.eir.elc.vim.tmp && mv out/swapcase.c.eir.elc.vim.tmp out/swapcase.c.eir.elc.vim
(echo vim && cat out/nullptr.c.eir) | out/elc.c.eir.x86 > out/nullptr.c.eir.elc.vim.tmp && mv out/nullptr.c.eir.elc.vim.tmp out/nullptr.c.eir.elc.vim
(echo vim && cat out/puts.c.eir) | out/elc.c.eir.x86 > out/puts.c.eir.elc.vim.tmp && mv out/puts.c.eir.elc.vim.tmp out/puts.c.eir.elc.vim
(echo vim && cat out/print_int.c.eir) | out/elc.c.eir.x86 > out/print_int.c.eir.elc.vim.tmp && mv out/print_int.c.eir.elc.vim.tmp out/print_int.c.eir.elc.vim
(echo vim && cat out/logic_val.c.eir) | out/elc.c.eir.x86 > out/logic_val.c.eir.elc.vim.tmp && mv out/logic_val.c.eir.elc.vim.tmp out/logic_val.c.eir.elc.vim
(echo vim && cat out/global_array.c.eir) | out/elc.c.eir.x86 > out/global_array.c.eir.elc.vim.tmp && mv out/global_array.c.eir.elc.vim.tmp out/global_array.c.eir.elc.vim
(echo vim && cat out/fizzbuzz_fast.c.eir) | out/elc.c.eir.x86 > out/fizzbuzz_fast.c.eir.elc.vim.tmp && mv out/fizzbuzz_fast.c.eir.elc.vim.tmp out/fizzbuzz_fast.c.eir.elc.vim
(echo vim && cat out/hello.c.eir) | out/elc.c.eir.x86 > out/hello.c.eir.elc.vim.tmp && mv out/hello.c.eir.elc.vim.tmp out/hello.c.eir.elc.vim
(echo vim && cat out/switch_op.c.eir) | out/elc.c.eir.x86 > out/switch_op.c.eir.elc.vim.tmp && mv out/switch_op.c.eir.elc.vim.tmp out/switch_op.c.eir.elc.vim
(echo vim && cat out/24_muldiv.c.eir) | out/elc.c.eir.x86 > out/24_muldiv.c.eir.elc.vim.tmp && mv out/24_muldiv.c.eir.elc.vim.tmp out/24_muldiv.c.eir.elc.vim
(echo vim && cat out/func_ptr.c.eir) | out/elc.c.eir.x86 > out/func_ptr.c.eir.elc.vim.tmp && mv out/func_ptr.c.eir.elc.vim.tmp out/func_ptr.c.eir.elc.vim
(echo vim && cat out/cmp_gt.c.eir) | out/elc.c.eir.x86 > out/cmp_gt.c.eir.elc.vim.tmp && mv out/cmp_gt.c.eir.elc.vim.tmp out/cmp_gt.c.eir.elc.vim
(echo vim && cat out/getchar.c.eir) | out/elc.c.eir.x86 > out/getchar.c.eir.elc.vim.tmp && mv out/getchar.c.eir.elc.vim.tmp out/getchar.c.eir.elc.vim
(echo vim && cat out/8cc.in.c.eir) | out/elc.c.eir.x86 > out/8cc.in.c.eir.elc.vim.tmp && mv out/8cc.in.c.eir.elc.vim.tmp out/8cc.in.c.eir.elc.vim
(echo vim && cat out/malloc.c.eir) | out/elc.c.eir.x86 > out/malloc.c.eir.elc.vim.tmp && mv out/malloc.c.eir.elc.vim.tmp out/malloc.c.eir.elc.vim
(echo vim && cat out/cmp_ge.c.eir) | out/elc.c.eir.x86 > out/cmp_ge.c.eir.elc.vim.tmp && mv out/cmp_ge.c.eir.elc.vim.tmp out/cmp_ge.c.eir.elc.vim
(echo vim && cat out/increment.c.eir) | out/elc.c.eir.x86 > out/increment.c.eir.elc.vim.tmp && mv out/increment.c.eir.elc.vim.tmp out/increment.c.eir.elc.vim
(echo vim && cat out/24_cmp2.c.eir) | out/elc.c.eir.x86 > out/24_cmp2.c.eir.elc.vim.tmp && mv out/24_cmp2.c.eir.elc.vim.tmp out/24_cmp2.c.eir.elc.vim
(echo vim && cat out/putchar.c.eir) | out/elc.c.eir.x86 > out/putchar.c.eir.elc.vim.tmp && mv out/putchar.c.eir.elc.vim.tmp out/putchar.c.eir.elc.vim
(echo vim && cat out/eof.c.eir) | out/elc.c.eir.x86 > out/eof.c.eir.elc.vim.tmp && mv out/eof.c.eir.elc.vim.tmp out/eof.c.eir.elc.vim
(echo vim && cat out/24_cmp.c.eir) | out/elc.c.eir.x86 > out/24_cmp.c.eir.elc.vim.tmp && mv out/24_cmp.c.eir.elc.vim.tmp out/24_cmp.c.eir.elc.vim
(echo vim && cat out/lisp.c.eir) | out/elc.c.eir.x86 > out/lisp.c.eir.elc.vim.tmp && mv out/lisp.c.eir.elc.vim.tmp out/lisp.c.eir.elc.vim
(echo vim && cat out/func.c.eir) | out/elc.c.eir.x86 > out/func.c.eir.elc.vim.tmp && mv out/func.c.eir.elc.vim.tmp out/func.c.eir.elc.vim
(echo vim && cat out/muldiv.c.eir) | out/elc.c.eir.x86 > out/muldiv.c.eir.elc.vim.tmp && mv out/muldiv.c.eir.elc.vim.tmp out/muldiv.c.eir.elc.vim
(echo vim && cat out/array.c.eir) | out/elc.c.eir.x86 > out/array.c.eir.elc.vim.tmp && mv out/array.c.eir.elc.vim.tmp out/array.c.eir.elc.vim
(echo vim && cat out/loop.c.eir) | out/elc.c.eir.x86 > out/loop.c.eir.elc.vim.tmp && mv out/loop.c.eir.elc.vim.tmp out/loop.c.eir.elc.vim
(echo vim && cat out/copy_struct.c.eir) | out/elc.c.eir.x86 > out/copy_struct.c.eir.elc.vim.tmp && mv out/copy_struct.c.eir.elc.vim.tmp out/copy_struct.c.eir.elc.vim
(echo vim && cat out/cmp_lt.c.eir) | out/elc.c.eir.x86 > out/cmp_lt.c.eir.elc.vim.tmp && mv out/cmp_lt.c.eir.elc.vim.tmp out/cmp_lt.c.eir.elc.vim
(echo vim && cat out/8cc.c.eir) | out/elc.c.eir.x86 > out/8cc.c.eir.elc.vim.tmp && mv out/8cc.c.eir.elc.vim.tmp out/8cc.c.eir.elc.vim
(echo vim && cat out/elc.c.eir) | out/elc.c.eir.x86 > out/elc.c.eir.elc.vim.tmp && mv out/elc.c.eir.elc.vim.tmp out/elc.c.eir.elc.vim
(echo vim && cat out/dump_ir.c.eir) | out/elc.c.eir.x86 > out/dump_ir.c.eir.elc.vim.tmp && mv out/dump_ir.c.eir.elc.vim.tmp out/dump_ir.c.eir.elc.vim
(echo vim && cat out/eli.c.eir) | out/elc.c.eir.x86 > out/eli.c.eir.elc.vim.tmp && mv out/eli.c.eir.elc.vim.tmp out/eli.c.eir.elc.vim
(diff -u out/00exit.eir.vim out/00exit.eir.elc.vim > out/00exit.eir.elc.vim.diff.tmp && mv out/00exit.eir.elc.vim.diff.tmp out/00exit.eir.elc.vim.diff) || (cat out/00exit.eir.elc.vim.diff.tmp ; false)
(diff -u out/01putc.eir.vim out/01putc.eir.elc.vim > out/01putc.eir.elc.vim.diff.tmp && mv out/01putc.eir.elc.vim.diff.tmp out/01putc.eir.elc.vim.diff) || (cat out/01putc.eir.elc.vim.diff.tmp ; false)
(diff -u out/02mov.eir.vim out/02mov.eir.elc.vim > out/02mov.eir.elc.vim.diff.tmp && mv out/02mov.eir.elc.vim.diff.tmp out/02mov.eir.elc.vim.diff) || (cat out/02mov.eir.elc.vim.diff.tmp ; false)
(diff -u out/03mov_reg.eir.vim out/03mov_reg.eir.elc.vim > out/03mov_reg.eir.elc.vim.diff.tmp && mv out/03mov_reg.eir.elc.vim.diff.tmp out/03mov_reg.eir.elc.vim.diff) || (cat out/03mov_reg.eir.elc.vim.diff.tmp ; false)
(diff -u out/04getc.eir.vim out/04getc.eir.elc.vim > out/04getc.eir.elc.vim.diff.tmp && mv out/04getc.eir.elc.vim.diff.tmp out/04getc.eir.elc.vim.diff) || (cat out/04getc.eir.elc.vim.diff.tmp ; false)
(diff -u out/05regjmp.eir.vim out/05regjmp.eir.elc.vim > out/05regjmp.eir.elc.vim.diff.tmp && mv out/05regjmp.eir.elc.vim.diff.tmp out/05regjmp.eir.elc.vim.diff) || (cat out/05regjmp.eir.elc.vim.diff.tmp ; false)
(diff -u out/06mem.eir.vim out/06mem.eir.elc.vim > out/06mem.eir.elc.vim.diff.tmp && mv out/06mem.eir.elc.vim.diff.tmp out/06mem.eir.elc.vim.diff) || (cat out/06mem.eir.elc.vim.diff.tmp ; false)
(diff -u out/07mem.eir.vim out/07mem.eir.elc.vim > out/07mem.eir.elc.vim.diff.tmp && mv out/07mem.eir.elc.vim.diff.tmp out/07mem.eir.elc.vim.diff) || (cat out/07mem.eir.elc.vim.diff.tmp ; false)
(diff -u out/08data.eir.vim out/08data.eir.elc.vim > out/08data.eir.elc.vim.diff.tmp && mv out/08data.eir.elc.vim.diff.tmp out/08data.eir.elc.vim.diff) || (cat out/08data.eir.elc.vim.diff.tmp ; false)
(diff -u out/add_self.eir.vim out/add_self.eir.elc.vim > out/add_self.eir.elc.vim.diff.tmp && mv out/add_self.eir.elc.vim.diff.tmp out/add_self.eir.elc.vim.diff) || (cat out/add_self.eir.elc.vim.diff.tmp ; false)
(diff -u out/basic.eir.vim out/basic.eir.elc.vim > out/basic.eir.elc.vim.diff.tmp && mv out/basic.eir.elc.vim.diff.tmp out/basic.eir.elc.vim.diff) || (cat out/basic.eir.elc.vim.diff.tmp ; false)
(diff -u out/bug_cmp.eir.vim out/bug_cmp.eir.elc.vim > out/bug_cmp.eir.elc.vim.diff.tmp && mv out/bug_cmp.eir.elc.vim.diff.tmp out/bug_cmp.eir.elc.vim.diff) || (cat out/bug_cmp.eir.elc.vim.diff.tmp ; false)
(diff -u out/echo.eir.vim out/echo.eir.elc.vim > out/echo.eir.elc.vim.diff.tmp && mv out/echo.eir.elc.vim.diff.tmp out/echo.eir.elc.vim.diff) || (cat out/echo.eir.elc.vim.diff.tmp ; false)
(diff -u out/isprint.eir.vim out/isprint.eir.elc.vim > out/isprint.eir.elc.vim.diff.tmp && mv out/isprint.eir.elc.vim.diff.tmp out/isprint.eir.elc.vim.diff) || (cat out/isprint.eir.elc.vim.diff.tmp ; false)
(diff -u out/neg.eir.vim out/neg.eir.elc.vim > out/neg.eir.elc.vim.diff.tmp && mv out/neg.eir.elc.vim.diff.tmp out/neg.eir.elc.vim.diff) || (cat out/neg.eir.elc.vim.diff.tmp ; false)
(diff -u out/sub.eir.vim out/sub.eir.elc.vim > out/sub.eir.elc.vim.diff.tmp && mv out/sub.eir.elc.vim.diff.tmp out/sub.eir.elc.vim.diff) || (cat out/sub.eir.elc.vim.diff.tmp ; false)
(diff -u out/sub_bug.eir.vim out/sub_bug.eir.elc.vim > out/sub_bug.eir.elc.vim.diff.tmp && mv out/sub_bug.eir.elc.vim.diff.tmp out/sub_bug.eir.elc.vim.diff) || (cat out/sub_bug.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmps.eir.vim out/cmps.eir.elc.vim > out/cmps.eir.elc.vim.diff.tmp && mv out/cmps.eir.elc.vim.diff.tmp out/cmps.eir.elc.vim.diff) || (cat out/cmps.eir.elc.vim.diff.tmp ; false)
(diff -u out/jmps.eir.vim out/jmps.eir.elc.vim > out/jmps.eir.elc.vim.diff.tmp && mv out/jmps.eir.elc.vim.diff.tmp out/jmps.eir.elc.vim.diff) || (cat out/jmps.eir.elc.vim.diff.tmp ; false)
(diff -u out/24_mem.eir.vim out/24_mem.eir.elc.vim > out/24_mem.eir.elc.vim.diff.tmp && mv out/24_mem.eir.elc.vim.diff.tmp out/24_mem.eir.elc.vim.diff) || (cat out/24_mem.eir.elc.vim.diff.tmp ; false)
(diff -u out/bm_mov.eir.vim out/bm_mov.eir.elc.vim > out/bm_mov.eir.elc.vim.diff.tmp && mv out/bm_mov.eir.elc.vim.diff.tmp out/bm_mov.eir.elc.vim.diff) || (cat out/bm_mov.eir.elc.vim.diff.tmp ; false)
(diff -u out/func2.c.eir.vim out/func2.c.eir.elc.vim > out/func2.c.eir.elc.vim.diff.tmp && mv out/func2.c.eir.elc.vim.diff.tmp out/func2.c.eir.elc.vim.diff) || (cat out/func2.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/fizzbuzz.c.eir.vim out/fizzbuzz.c.eir.elc.vim > out/fizzbuzz.c.eir.elc.vim.diff.tmp && mv out/fizzbuzz.c.eir.elc.vim.diff.tmp out/fizzbuzz.c.eir.elc.vim.diff) || (cat out/fizzbuzz.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/addsub.c.eir.vim out/addsub.c.eir.elc.vim > out/addsub.c.eir.elc.vim.diff.tmp && mv out/addsub.c.eir.elc.vim.diff.tmp out/addsub.c.eir.elc.vim.diff) || (cat out/addsub.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/printf.c.eir.vim out/printf.c.eir.elc.vim > out/printf.c.eir.elc.vim.diff.tmp && mv out/printf.c.eir.elc.vim.diff.tmp out/printf.c.eir.elc.vim.diff) || (cat out/printf.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/switch_range.c.eir.vim out/switch_range.c.eir.elc.vim > out/switch_range.c.eir.elc.vim.diff.tmp && mv out/switch_range.c.eir.elc.vim.diff.tmp out/switch_range.c.eir.elc.vim.diff) || (cat out/switch_range.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/struct.c.eir.vim out/struct.c.eir.elc.vim > out/struct.c.eir.elc.vim.diff.tmp && mv out/struct.c.eir.elc.vim.diff.tmp out/struct.c.eir.elc.vim.diff) || (cat out/struct.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_eq.c.eir.vim out/cmp_eq.c.eir.elc.vim > out/cmp_eq.c.eir.elc.vim.diff.tmp && mv out/cmp_eq.c.eir.elc.vim.diff.tmp out/cmp_eq.c.eir.elc.vim.diff) || (cat out/cmp_eq.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/switch_case.c.eir.vim out/switch_case.c.eir.elc.vim > out/switch_case.c.eir.elc.vim.diff.tmp && mv out/switch_case.c.eir.elc.vim.diff.tmp out/switch_case.c.eir.elc.vim.diff) || (cat out/switch_case.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_ne.c.eir.vim out/cmp_ne.c.eir.elc.vim > out/cmp_ne.c.eir.elc.vim.diff.tmp && mv out/cmp_ne.c.eir.elc.vim.diff.tmp out/cmp_ne.c.eir.elc.vim.diff) || (cat out/cmp_ne.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/global_struct_ref.c.eir.vim out/global_struct_ref.c.eir.elc.vim > out/global_struct_ref.c.eir.elc.vim.diff.tmp && mv out/global_struct_ref.c.eir.elc.vim.diff.tmp out/global_struct_ref.c.eir.elc.vim.diff) || (cat out/global_struct_ref.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_le.c.eir.vim out/cmp_le.c.eir.elc.vim > out/cmp_le.c.eir.elc.vim.diff.tmp && mv out/cmp_le.c.eir.elc.vim.diff.tmp out/cmp_le.c.eir.elc.vim.diff) || (cat out/cmp_le.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/global.c.eir.vim out/global.c.eir.elc.vim > out/global.c.eir.elc.vim.diff.tmp && mv out/global.c.eir.elc.vim.diff.tmp out/global.c.eir.elc.vim.diff) || (cat out/global.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/field_addr.c.eir.vim out/field_addr.c.eir.elc.vim > out/field_addr.c.eir.elc.vim.diff.tmp && mv out/field_addr.c.eir.elc.vim.diff.tmp out/field_addr.c.eir.elc.vim.diff) || (cat out/field_addr.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/swapcase.c.eir.vim out/swapcase.c.eir.elc.vim > out/swapcase.c.eir.elc.vim.diff.tmp && mv out/swapcase.c.eir.elc.vim.diff.tmp out/swapcase.c.eir.elc.vim.diff) || (cat out/swapcase.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/nullptr.c.eir.vim out/nullptr.c.eir.elc.vim > out/nullptr.c.eir.elc.vim.diff.tmp && mv out/nullptr.c.eir.elc.vim.diff.tmp out/nullptr.c.eir.elc.vim.diff) || (cat out/nullptr.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/puts.c.eir.vim out/puts.c.eir.elc.vim > out/puts.c.eir.elc.vim.diff.tmp && mv out/puts.c.eir.elc.vim.diff.tmp out/puts.c.eir.elc.vim.diff) || (cat out/puts.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/print_int.c.eir.vim out/print_int.c.eir.elc.vim > out/print_int.c.eir.elc.vim.diff.tmp && mv out/print_int.c.eir.elc.vim.diff.tmp out/print_int.c.eir.elc.vim.diff) || (cat out/print_int.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/logic_val.c.eir.vim out/logic_val.c.eir.elc.vim > out/logic_val.c.eir.elc.vim.diff.tmp && mv out/logic_val.c.eir.elc.vim.diff.tmp out/logic_val.c.eir.elc.vim.diff) || (cat out/logic_val.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/global_array.c.eir.vim out/global_array.c.eir.elc.vim > out/global_array.c.eir.elc.vim.diff.tmp && mv out/global_array.c.eir.elc.vim.diff.tmp out/global_array.c.eir.elc.vim.diff) || (cat out/global_array.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/fizzbuzz_fast.c.eir.vim out/fizzbuzz_fast.c.eir.elc.vim > out/fizzbuzz_fast.c.eir.elc.vim.diff.tmp && mv out/fizzbuzz_fast.c.eir.elc.vim.diff.tmp out/fizzbuzz_fast.c.eir.elc.vim.diff) || (cat out/fizzbuzz_fast.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/hello.c.eir.vim out/hello.c.eir.elc.vim > out/hello.c.eir.elc.vim.diff.tmp && mv out/hello.c.eir.elc.vim.diff.tmp out/hello.c.eir.elc.vim.diff) || (cat out/hello.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/switch_op.c.eir.vim out/switch_op.c.eir.elc.vim > out/switch_op.c.eir.elc.vim.diff.tmp && mv out/switch_op.c.eir.elc.vim.diff.tmp out/switch_op.c.eir.elc.vim.diff) || (cat out/switch_op.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/24_muldiv.c.eir.vim out/24_muldiv.c.eir.elc.vim > out/24_muldiv.c.eir.elc.vim.diff.tmp && mv out/24_muldiv.c.eir.elc.vim.diff.tmp out/24_muldiv.c.eir.elc.vim.diff) || (cat out/24_muldiv.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/func_ptr.c.eir.vim out/func_ptr.c.eir.elc.vim > out/func_ptr.c.eir.elc.vim.diff.tmp && mv out/func_ptr.c.eir.elc.vim.diff.tmp out/func_ptr.c.eir.elc.vim.diff) || (cat out/func_ptr.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_gt.c.eir.vim out/cmp_gt.c.eir.elc.vim > out/cmp_gt.c.eir.elc.vim.diff.tmp && mv out/cmp_gt.c.eir.elc.vim.diff.tmp out/cmp_gt.c.eir.elc.vim.diff) || (cat out/cmp_gt.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/getchar.c.eir.vim out/getchar.c.eir.elc.vim > out/getchar.c.eir.elc.vim.diff.tmp && mv out/getchar.c.eir.elc.vim.diff.tmp out/getchar.c.eir.elc.vim.diff) || (cat out/getchar.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/8cc.in.c.eir.vim out/8cc.in.c.eir.elc.vim > out/8cc.in.c.eir.elc.vim.diff.tmp && mv out/8cc.in.c.eir.elc.vim.diff.tmp out/8cc.in.c.eir.elc.vim.diff) || (cat out/8cc.in.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/malloc.c.eir.vim out/malloc.c.eir.elc.vim > out/malloc.c.eir.elc.vim.diff.tmp && mv out/malloc.c.eir.elc.vim.diff.tmp out/malloc.c.eir.elc.vim.diff) || (cat out/malloc.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_ge.c.eir.vim out/cmp_ge.c.eir.elc.vim > out/cmp_ge.c.eir.elc.vim.diff.tmp && mv out/cmp_ge.c.eir.elc.vim.diff.tmp out/cmp_ge.c.eir.elc.vim.diff) || (cat out/cmp_ge.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/increment.c.eir.vim out/increment.c.eir.elc.vim > out/increment.c.eir.elc.vim.diff.tmp && mv out/increment.c.eir.elc.vim.diff.tmp out/increment.c.eir.elc.vim.diff) || (cat out/increment.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/24_cmp2.c.eir.vim out/24_cmp2.c.eir.elc.vim > out/24_cmp2.c.eir.elc.vim.diff.tmp && mv out/24_cmp2.c.eir.elc.vim.diff.tmp out/24_cmp2.c.eir.elc.vim.diff) || (cat out/24_cmp2.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/putchar.c.eir.vim out/putchar.c.eir.elc.vim > out/putchar.c.eir.elc.vim.diff.tmp && mv out/putchar.c.eir.elc.vim.diff.tmp out/putchar.c.eir.elc.vim.diff) || (cat out/putchar.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/eof.c.eir.vim out/eof.c.eir.elc.vim > out/eof.c.eir.elc.vim.diff.tmp && mv out/eof.c.eir.elc.vim.diff.tmp out/eof.c.eir.elc.vim.diff) || (cat out/eof.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/24_cmp.c.eir.vim out/24_cmp.c.eir.elc.vim > out/24_cmp.c.eir.elc.vim.diff.tmp && mv out/24_cmp.c.eir.elc.vim.diff.tmp out/24_cmp.c.eir.elc.vim.diff) || (cat out/24_cmp.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/lisp.c.eir.vim out/lisp.c.eir.elc.vim > out/lisp.c.eir.elc.vim.diff.tmp && mv out/lisp.c.eir.elc.vim.diff.tmp out/lisp.c.eir.elc.vim.diff) || (cat out/lisp.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/func.c.eir.vim out/func.c.eir.elc.vim > out/func.c.eir.elc.vim.diff.tmp && mv out/func.c.eir.elc.vim.diff.tmp out/func.c.eir.elc.vim.diff) || (cat out/func.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/muldiv.c.eir.vim out/muldiv.c.eir.elc.vim > out/muldiv.c.eir.elc.vim.diff.tmp && mv out/muldiv.c.eir.elc.vim.diff.tmp out/muldiv.c.eir.elc.vim.diff) || (cat out/muldiv.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/array.c.eir.vim out/array.c.eir.elc.vim > out/array.c.eir.elc.vim.diff.tmp && mv out/array.c.eir.elc.vim.diff.tmp out/array.c.eir.elc.vim.diff) || (cat out/array.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/loop.c.eir.vim out/loop.c.eir.elc.vim > out/loop.c.eir.elc.vim.diff.tmp && mv out/loop.c.eir.elc.vim.diff.tmp out/loop.c.eir.elc.vim.diff) || (cat out/loop.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/copy_struct.c.eir.vim out/copy_struct.c.eir.elc.vim > out/copy_struct.c.eir.elc.vim.diff.tmp && mv out/copy_struct.c.eir.elc.vim.diff.tmp out/copy_struct.c.eir.elc.vim.diff) || (cat out/copy_struct.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/cmp_lt.c.eir.vim out/cmp_lt.c.eir.elc.vim > out/cmp_lt.c.eir.elc.vim.diff.tmp && mv out/cmp_lt.c.eir.elc.vim.diff.tmp out/cmp_lt.c.eir.elc.vim.diff) || (cat out/cmp_lt.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/8cc.c.eir.vim out/8cc.c.eir.elc.vim > out/8cc.c.eir.elc.vim.diff.tmp && mv out/8cc.c.eir.elc.vim.diff.tmp out/8cc.c.eir.elc.vim.diff) || (cat out/8cc.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/elc.c.eir.vim out/elc.c.eir.elc.vim > out/elc.c.eir.elc.vim.diff.tmp && mv out/elc.c.eir.elc.vim.diff.tmp out/elc.c.eir.elc.vim.diff) || (cat out/elc.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/dump_ir.c.eir.vim out/dump_ir.c.eir.elc.vim > out/dump_ir.c.eir.elc.vim.diff.tmp && mv out/dump_ir.c.eir.elc.vim.diff.tmp out/dump_ir.c.eir.elc.vim.diff) || (cat out/dump_ir.c.eir.elc.vim.diff.tmp ; false)
(diff -u out/eli.c.eir.vim out/eli.c.eir.elc.vim > out/eli.c.eir.elc.vim.diff.tmp && mv out/eli.c.eir.elc.vim.diff.tmp out/eli.c.eir.elc.vim.diff) || (cat out/eli.c.eir.elc.vim.diff.tmp ; false)
</details>

My environment:

- Ubuntu 15.10
- GCC 5.2.1
- Vim 7.4-712
