### PR TITLE
Add Crystal (compile-time) backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ COBJS := $(addprefix out/,$(notdir $(CSRCS:.c=.o)))
 $(COBJS): out/%.o: ir/%.c
 	$(CC) -c -I. $(CFLAGS) $< -o $@
 
-ELC_SRCS := elc.c util.c rb.c py.c tf.c js.c php.c el.c vim.c tex.c cl.c sh.c sed.c java.c swift.c c.c cpp.c x86.c i.c ws.c piet.c pietasm.c bef.c bf.c unl.c
+ELC_SRCS := elc.c util.c rb.c py.c tf.c js.c php.c el.c vim.c tex.c cl.c sh.c sed.c java.c swift.c cr.c c.c cpp.c x86.c i.c ws.c piet.c pietasm.c bef.c bf.c unl.c
 ELC_SRCS := $(addprefix target/,$(ELC_SRCS))
 COBJS := $(addprefix out/,$(notdir $(ELC_SRCS:.c=.o)))
 $(COBJS): out/%.o: target/%.c
@@ -243,6 +243,12 @@ RUNNER := tools/runswift.sh
 TOOL := swiftc
 include target.mk
 $(OUT.eir.swift.out): tools/runswift.sh
+
+TARGET := cr
+RUNNER := tools/runcr.sh
+TOOL := crystal
+include target.mk
+$(OUT.eir.crystal.out): tools/runcr.sh
 
 TARGET := c
 RUNNER := tools/runc.sh

--- a/target/cr.c
+++ b/target/cr.c
@@ -1,0 +1,151 @@
+#include <ir/ir.h>
+#include <target/util.h>
+
+static const char* CR_REG_NAMES[] = {
+  "@a", "@b", "@c", "@d", "@bp", "@sp", "@pc"
+};
+
+static void init_state_cr(Data* data) {
+  reg_names = CR_REG_NAMES;
+  emit_line("module Main");
+  inc_indent();
+  for (int i = 0; i < 7; i++) {
+    emit_line("property %s", reg_names[i] + 1);
+  }
+  emit_line("");
+  emit_line("def initialize");
+  inc_indent();
+  for (int i = 0; i < 7; i++) {
+    emit_line("%s = 0", reg_names[i]);
+  }
+  emit_line("@mem = [0] * (1 << 24)");
+  for (int mp = 0; data; data = data->next, mp++) {
+    if (data->v) {
+      emit_line("@mem[%d] = %d", mp, data->v);
+    }
+  }
+  dec_indent();
+  emit_line("end");
+}
+
+static void cr_emit_func_prologue(int func_id) {
+  emit_line("");
+  emit_line("def func%d", func_id);
+  inc_indent();
+  emit_line("while %d <= @pc && @pc < %d",
+            func_id * CHUNKED_FUNC_SIZE, (func_id + 1) * CHUNKED_FUNC_SIZE);
+  inc_indent();
+  emit_line("case @pc");
+  inc_indent();
+}
+
+static void cr_emit_func_epilogue(void) {
+  dec_indent();
+  emit_line("end");
+  emit_line("@pc += 1");
+  dec_indent();
+  emit_line("end");
+  dec_indent();
+  emit_line("end");
+}
+
+static void cr_emit_pc_change(int pc) {
+  emit_line("");
+  dec_indent();
+  emit_line("when %d", pc);
+  inc_indent();
+}
+
+static void cr_emit_inst(Inst* inst) {
+  switch (inst->op) {
+  case MOV:
+    emit_line("%s = %s", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case ADD:
+    emit_line("%s = (%s + %s) & " UINT_MAX_STR,
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case SUB:
+    emit_line("%s = (%s - %s) & " UINT_MAX_STR,
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case LOAD:
+    emit_line("%s = @mem[%s]", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case STORE:
+    emit_line("@mem[%s] = %s", src_str(inst), reg_names[inst->dst.reg]);
+    break;
+
+  case PUTC:
+    emit_line("putc %s", src_str(inst));
+    break;
+
+  case GETC:
+    emit_line("c = STDIN.getc; %s = c ? c.ord : 0",
+              reg_names[inst->dst.reg]);
+    break;
+
+  case EXIT:
+    emit_line("exit");
+    break;
+
+  case DUMP:
+    break;
+
+  case EQ:
+  case NE:
+  case LT:
+  case GT:
+  case LE:
+  case GE:
+    emit_line("%s = %s ? 1 : 0",
+              reg_names[inst->dst.reg], cmp_str(inst, "true"));
+    break;
+
+  case JEQ:
+  case JNE:
+  case JLT:
+  case JGT:
+  case JLE:
+  case JGE:
+  case JMP:
+    emit_line("%s && @pc = %s - 1",
+              cmp_str(inst, "true"), value_str(&inst->jmp));
+    break;
+
+  default:
+    error("oops");
+  }
+}
+
+void target_cr(Module* module) {
+  init_state_cr(module->data);
+  emit_line("");
+
+  int num_funcs = emit_chunked_main_loop(module->text,
+                                         cr_emit_func_prologue,
+                                         cr_emit_func_epilogue,
+                                         cr_emit_pc_change,
+                                         cr_emit_inst);
+  dec_indent();
+  emit_line("end");
+
+  emit_line("");
+  emit_line("main = Main.new");
+  emit_line("while true");
+  inc_indent();
+  emit_line("case main.pc / %d", CHUNKED_FUNC_SIZE);
+  for (int i = 0; i < num_funcs; i++) {
+    emit_line("when %d", i);
+    emit_line(" main.func%d", i);
+  }
+  emit_line("end");
+  dec_indent();
+  emit_line("end");
+}

--- a/target/elc.c
+++ b/target/elc.c
@@ -18,6 +18,7 @@ void target_sh(Module* module);
 void target_sed(Module* module);
 void target_java(Module* module);
 void target_swift(Module* module);
+void target_cr(Module* module);
 void target_c(Module* module);
 void target_cpp(Module* module);
 void target_x86(Module* module);
@@ -57,6 +58,8 @@ static target_func_t get_target_func(const char* ext) {
     return target_java;
   } else if (!strcmp(ext, "swift")) {
     return target_swift;
+  } else if (!strcmp(ext, "cr")) {
+    return target_cr;
   } else if (!strcmp(ext, "c")) {
     return target_c;
   } else if (!strcmp(ext, "cpp")) {

--- a/tools/runcr.sh
+++ b/tools/runcr.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-crystal build $1 -o $1.exe
-./$1.exe
+crystal build --no-codegen "$1" 2>&1

--- a/tools/runcr.sh
+++ b/tools/runcr.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+crystal build $1 -o $1.exe
+./$1.exe


### PR DESCRIPTION
This pull request has two commits. One is the implementation of backend for Crystal (normal, compile-then-run), and another is the implementation of backend for Crystal (compile-time only). I think you prefer compile-time version, so compile-time version remains.