### PR TITLE
Wrap a macro-expanded if statement with do {} while (0).

### DIFF
--- a/libc/assert.h
+++ b/libc/assert.h
@@ -6,9 +6,11 @@
 void exit(int s);
 
 #define assert(x)                               \
-  if (!(x)) {                                   \
-    print_str("assertion failed: " #x "\n");    \
-    exit(1);                                    \
-  }
+  do {                                          \
+    if (!(x)) {                                 \
+      print_str("assertion failed: " #x "\n");  \
+      exit(1);                                  \
+    }                                           \
+  } while (0)
 
 #endif  // ELVM_LIBC_ASSERT_H_


### PR DESCRIPTION
Previously, [1] is expanded to a statement equivalent to [2]
which is obviously not intended.

```
  [1]
  if (foo)
    assert(cond);
  else
    bar();

  [2]
  if (foo) {
    if (!(cond)) {
      print_str("assertion failed: " #x "\n");
      exit(1);
    } else {
      bar();
    }
  }
```