### PR TITLE
Tuning Perl5 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unlike LLVM bitcode, EIR is designed to be extremely simple, so
 there's more chance we can write a translator from EIR to an esoteric
 language.
 
-Currently, there are 27 backends:
+Currently, there are 28 backends:
 
 * Bash
 * Befunge
@@ -28,6 +28,7 @@ Currently, there are 27 backends:
 * Go (by [@shogo82148](https://github.com/shogo82148/))
 * Java
 * JavaScript
+* Perl5 (by [@mackee](https://github.com/mackee/))
 * PHP
 * Piet
 * Python


### PR DESCRIPTION
Perl5 target has already implemented (#22 and http://qiita.com/mackee_w/items/5397d6b9215f41c41db1), but it is not in README.md
So I added missing target(Perl5) into README.md

And speed up Perl5 target.

Before:
```
$ time ./runtest.sh out/8cc.c.eir.pl.out perl out/8cc.c.eir.pl
real	0m5.787s
user	0m5.561s
sys	0m0.159s
```

After:
```
$ time ./runtest.sh out/8cc.c.eir.pl.out perl out/8cc.c.eir.pl

real	0m1.083s
user	0m0.903s
sys	0m0.132s
```