### PR TITLE
SQLite3 backend 2fixes

### DIFF
--- a/target/sqlite3.c
+++ b/target/sqlite3.c
@@ -267,8 +267,6 @@ void target_sqlite3(Module* module) {
   sqlite3_emit_stdin();
   sqlite3_emit_data(module->data);
 
-  emit_line("-- .stats on");
-
   emit_line("WITH");
   inc_indent();
   emit_line("elvm AS (");

--- a/tools/runsqlite3.sh
+++ b/tools/runsqlite3.sh
@@ -5,7 +5,6 @@ set -e
 dir=$(mktemp -d)
 mkdir -p $dir
 infile=${dir}/input.txt
-#infile=input.txt
 cat > $infile
 
 cp $1 ${dir}/


### PR DESCRIPTION
#### 1. Reduce the number of recursion

In the test of `8cc.c.eir.sqlite3`,
   - before: 3547156 cycles
   - after: 2617489 cycles

But processing speed has not been improved so much because `load`/`store` processes are bottleneck. 

#### 2. Output `module->data` as JSON into SELECT clause, instead of creating data table

To make it easy to combine two or more generated SQLs into one DB.