### PR TITLE
Fix newer versions of Java and g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ $(OUT.eir.c.out): tools/runc.sh tinycc/tcc
 
 TARGET := cpp
 RUNNER := tools/runcpp.sh
-TOOL := g++-6
+TOOL := g++
 include target.mk
 $(OUT.eir.cpp.out): tools/runcpp.sh
 

--- a/target/java.c
+++ b/target/java.c
@@ -62,8 +62,8 @@ static void java_emit_inst(Inst* inst) {
     break;
 
   case GETC:
-    emit_line("try { int _ = System.in.read(); "
-              "  %s = _ == -1 ? 0 : _; }"
+    emit_line("try { int __ = System.in.read(); "
+              "  %s = __ == -1 ? 0 : __; }"
               "catch (Exception e) {}",
               reg_names[inst->dst.reg]);
     break;

--- a/tools/runcpp.sh
+++ b/tools/runcpp.sh
@@ -16,6 +16,6 @@ else
   echo ')"' >> $infile
 fi
 
-g++- -fconstexpr-loop-limit=1000000 ${dir}/$(basename $1) -o $1.exe
+g++ -fconstexpr-loop-limit=1000000 ${dir}/$(basename $1) -o $1.exe
 rm -fr $dir
 ./$1.exe

--- a/tools/runcpp.sh
+++ b/tools/runcpp.sh
@@ -16,6 +16,6 @@ else
   echo ')"' >> $infile
 fi
 
-g++-6 ${dir}/$(basename $1) -o $1.exe
+g++- -fconstexpr-loop-limit=1000000 ${dir}/$(basename $1) -o $1.exe
 rm -fr $dir
 ./$1.exe


### PR DESCRIPTION
- Java 9 made `_` a keyword, so instances of `_` are changed to `__` so that Java 9 is supported.
- Changed `g++-6` to `g++` to support g++ version 7 and newer.
- Increases constexpr loop limit so tests will pass with g++ >= 7