### PR TITLE
Fix potential fallthrough

### DIFF
--- a/tools/bfopt.cc
+++ b/tools/bfopt.cc
@@ -139,8 +139,8 @@ void parse(const char* code, vector<Op*>* ops) {
       case '@':
         if (g_verbose) {
           op->op = c;
-          break;
         }
+        break;
 
       default:
         delete op;


### PR DESCRIPTION
Recent versions of GCC complain about this potential fallthrough, which makes the build fail.