### PR TITLE
Add WebAssembly target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ ELC_SRCS := \
 	tm.c \
 	unl.c \
 	vim.c \
+	wasm.c \
 	ws.c \
 	x86.c \
 
@@ -259,6 +260,11 @@ include target.mk
 
 TARGET := asmjs
 RUNNER := nodejs
+include target.mk
+
+TARGET := wasm
+RUNNER := tools/runwasm.sh
+TOOL := wat2wasm
 include target.mk
 
 TARGET := php

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently, there are 35 backends:
 * Turing machine (by [@ND-CSE-30151](https://github.com/ND-CSE-30151/))
 * Unlambda (by [@irori](https://github.com/irori/))
 * Vim script (by [@rhysd](https://github.com/rhysd/))
+* WebAssembly (by [@dubek](https://github.com/dubek/))
 * Whitespace
 * arm-linux (by [@irori](https://github.com/irori/))
 * i386-linux
@@ -261,8 +262,7 @@ TODO: Reduce the size of the graph and run 8cc
 
 I'm interested in
 
-* adding more backends (e.g., WebAssembly, 16bit CPU, Malbolge
-  Unshackled, ...)
+* adding more backends (e.g., 16bit CPU, Malbolge Unshackled, ...)
 * running more programs (e.g., lua.bf or mruby.bf?)
 * supporting more C features (e.g., bit operations)
 * eliminating unnecessary code in 8cc

--- a/target/elc.c
+++ b/target/elc.c
@@ -44,6 +44,7 @@ void target_tf(Module* module);
 void target_tm(Module* module);
 void target_unl(Module* module);
 void target_vim(Module* module);
+void target_wasm(Module* module);
 void target_ws(Module* module);
 void target_x86(Module* module);
 
@@ -92,6 +93,7 @@ static target_func_t get_target_func(const char* ext) {
   if (!strcmp(ext, "tm")) return target_tm;
   if (!strcmp(ext, "unl")) return target_unl;
   if (!strcmp(ext, "vim")) return target_vim;
+  if (!strcmp(ext, "wasm")) return target_wasm;
   if (!strcmp(ext, "ws")) return target_ws;
   if (!strcmp(ext, "x86")) return target_x86;
   error("unknown flag: %s", ext);

--- a/target/wasm.c
+++ b/target/wasm.c
@@ -1,0 +1,224 @@
+#include <ir/ir.h>
+#include <target/util.h>
+
+// WebAssembly memory is specified in 64KiB pages
+#define WASM_MEM_SIZE_IN_PAGES 1024
+
+static void wasm_init_state(void) {
+  emit_line("(module");
+  inc_indent();
+  emit_line("(import \"env\" \"getchar\" (func $getchar (result i32)))");
+  emit_line("(import \"env\" \"putchar\" (func $putchar (param i32)))");
+  emit_line("(import \"env\" \"exit\" (func $exit))");
+  for (int i = 0; i < 7; i++) {
+    emit_line("(global $%s (mut i32) (i32.const 0))", reg_names[i]);
+  }
+  emit_line("(memory %d)", WASM_MEM_SIZE_IN_PAGES);
+}
+
+static void wasm_emit_func_prologue(int func_id) {
+  emit_line("");
+  emit_line("(func $func%d", func_id);
+  inc_indent();
+  emit_line("(loop $while0");
+  inc_indent();
+  emit_line("(if (i32.and (i32.le_s (i32.const %d) (get_global $pc))",
+            func_id * CHUNKED_FUNC_SIZE);
+  emit_line("             (i32.lt_s (get_global $pc) (i32.const %d)))",
+            (func_id + 1) * CHUNKED_FUNC_SIZE);
+  inc_indent();
+  emit_line("(then");
+  inc_indent();
+  emit_line("(block $while0body");
+  inc_indent();
+  // dummy first case
+  emit_line("(if (i32.eq (get_global $pc) (i32.const -1))");
+  inc_indent();
+  emit_line("(then");
+  inc_indent();
+}
+
+static void wasm_emit_func_epilogue(void) {
+  emit_line("(br $while0body)");
+  dec_indent();
+  emit_line(")"); // then
+  dec_indent();
+  emit_line(")"); // if
+  emit_line("");
+  dec_indent();
+  emit_line(")"); // block $while0body
+  emit_line("(set_global $pc (i32.add (get_global $pc) (i32.const 1)))");
+  emit_line("(br $while0)");
+  dec_indent();
+  emit_line(")"); // then
+  dec_indent();
+  emit_line(")"); // if
+  dec_indent();
+  emit_line(")"); // loop $while0
+  dec_indent();
+  emit_line(")"); // func
+}
+
+static void wasm_emit_pc_change(int pc) {
+  emit_line("(br $while0body)");
+  dec_indent();
+  emit_line(")"); // then
+  dec_indent();
+  emit_line(")"); // if
+  emit_line("");
+  emit_line("(if (i32.eq (get_global $pc) (i32.const %d))", pc);
+  inc_indent();
+  emit_line("(then");
+  inc_indent();
+}
+
+static const char* wasm_get_value(Value *v) {
+  if (v->type == REG) {
+    return format("(get_global $%s)", reg_names[v->reg]);
+  } else if (v->type == IMM) {
+    return format("(i32.const %d)", v->imm);
+  } else {
+    error("invalid src type");
+  }
+}
+
+static const char* wasm_cmp_expr(Inst* inst) {
+  int op = normalize_cond(inst->op, 0);
+  const char* op_str;
+  switch (op) {
+    case JEQ:
+      op_str = "i32.eq"; break;
+    case JNE:
+      op_str = "i32.ne"; break;
+    case JLT:
+      op_str = "i32.lt_s"; break;
+    case JGT:
+      op_str = "i32.gt_s"; break;
+    case JLE:
+      op_str = "i32.le_s"; break;
+    case JGE:
+      op_str = "i32.ge_s"; break;
+    default:
+      error("oops");
+  }
+  return format("(%s (get_global $%s) %s)",
+                op_str, reg_names[inst->dst.reg], wasm_get_value(&inst->src));
+}
+
+static void wasm_emit_inst(Inst* inst) {
+  switch (inst->op) {
+  case MOV:
+    emit_line("(set_global $%s %s)", reg_names[inst->dst.reg], wasm_get_value(&inst->src));
+    break;
+
+  case ADD:
+    emit_line("(set_global $%s (i32.and (i32.add (get_global $%s) %s) (i32.const " UINT_MAX_STR ")))",
+              reg_names[inst->dst.reg], reg_names[inst->dst.reg], wasm_get_value(&inst->src));
+    break;
+
+  case SUB:
+    emit_line("(set_global $%s (i32.and (i32.sub (get_global $%s) %s) (i32.const " UINT_MAX_STR ")))",
+              reg_names[inst->dst.reg], reg_names[inst->dst.reg], wasm_get_value(&inst->src));
+    break;
+
+  case LOAD:
+    emit_line("(set_global $%s (i32.load (i32.shl %s (i32.const 2))))",
+              reg_names[inst->dst.reg], wasm_get_value(&inst->src));
+    break;
+
+  case STORE:
+    emit_line("(i32.store (i32.shl %s (i32.const 2)) (get_global $%s))",
+              wasm_get_value(&inst->src), reg_names[inst->dst.reg]);
+    break;
+
+  case PUTC:
+    emit_line("(call $putchar %s)", wasm_get_value(&inst->src));
+    break;
+
+  case GETC:
+    emit_line("(set_global $%s (call $getchar))", reg_names[inst->dst.reg]);
+    break;
+
+  case EXIT:
+    emit_line("(call $exit)");
+    break;
+
+  case DUMP:
+    break;
+
+  case EQ:
+  case NE:
+  case LT:
+  case GT:
+  case LE:
+  case GE:
+    emit_line("(set_global $%s %s)", reg_names[inst->dst.reg], wasm_cmp_expr(inst));
+    break;
+
+  case JEQ:
+  case JNE:
+  case JLT:
+  case JGT:
+  case JLE:
+  case JGE:
+    emit_line("(if %s (then (set_global $pc %s) (br $while0)))",
+              wasm_cmp_expr(inst), wasm_get_value(&inst->jmp));
+    break;
+
+  case JMP:
+    emit_line("(set_global $pc %s)", wasm_get_value(&inst->jmp));
+    emit_line("(br $while0)");
+    break;
+
+  default:
+    error("oops");
+  }
+}
+
+void target_wasm(Module* module) {
+  wasm_init_state();
+
+  int num_funcs = emit_chunked_main_loop(module->text,
+                                         wasm_emit_func_prologue,
+                                         wasm_emit_func_epilogue,
+                                         wasm_emit_pc_change,
+                                         wasm_emit_inst);
+
+  emit_line("");
+  emit_line("(table anyfunc");
+  inc_indent();
+  emit_line("(elem");
+  inc_indent();
+  for (int i = 0; i < num_funcs; i++) {
+    emit_line("$func%d", i);
+  }
+  dec_indent();
+  emit_line(")"); // elem
+  dec_indent();
+  emit_line(")"); // table
+
+  emit_line("");
+  emit_line("(func (export \"wasmmain\")");
+  inc_indent();
+  emit_line("(local $chunk i32)");
+
+  Data* data = module->data;
+  for (int mp = 0; data; data = data->next, mp++) {
+    if (data->v) {
+      emit_line("(i32.store (i32.shl (i32.const %d) (i32.const 2)) (i32.const %d))", mp, data->v);
+    }
+  }
+
+  emit_line("");
+  emit_line("(loop $mainloop");
+  inc_indent();
+  emit_line("(call_indirect (i32.div_u (get_global $pc) (i32.const %d)))", CHUNKED_FUNC_SIZE);
+  emit_line("(br $mainloop)");
+  dec_indent();
+  emit_line(")"); // loop $mainloop
+
+  dec_indent();
+  emit_line(")"); // func wasmmain
+  dec_indent();
+  emit_line(")"); // module
+}

--- a/tools/run_compiled_wasm.js
+++ b/tools/run_compiled_wasm.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env nodejs
+
+const fs = require('fs');
+const util = require('util');
+const readFile = util.promisify(fs.readFile);
+
+var input = Buffer.from([]);
+var ip = 0;
+
+process.stdin.on('data', (chunk) => {
+  input = Buffer.concat([input, chunk])
+});
+
+const env = {
+  getchar: function() {
+    return input[ip++] | 0;
+  },
+
+  putchar: function(c) {
+    process.stdout.write(String.fromCharCode(c & 255));
+  },
+
+  exit: function() {
+    process.exit(0);
+  }
+}
+
+async function runWasm(filename) {
+  try {
+    const buf = await readFile(filename);
+    const module = await WebAssembly.compile(buf);
+    const instance = new WebAssembly.Instance(module, {env: env});
+    instance.exports.wasmmain();
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write("ERROR: " + e)
+    process.exit(1);
+  }
+}
+
+runWasm(process.argv[2]);

--- a/tools/runwasm.sh
+++ b/tools/runwasm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+# The wasm ELVM backend generates WebAssembly Text Format (.wat) files.
+
+# First we translate them to WebAssembly binary format (.wasm)
+wat2wasm $1 -o $1.wasm
+# And then run them
+nodejs tools/run_compiled_wasm.js $1.wasm


### PR DESCRIPTION
This backend generates WebAssembly Text format (`.wat`).  It then uses
the `wat2wasm` tool from the WebAssembly Binary Toolkit
(https://github.com/WebAssembly/wabt) to translate it to the WebAssembly
Binary format (`.wasm`).

Running the binary wasm files requires NodeJS 8.0 or later.