### PR TITLE
Make a cast instead of relying on preprocessor directive.

### DIFF
--- a/libc/stdint.h
+++ b/libc/stdint.h
@@ -18,12 +18,12 @@ typedef long time_t;
 #define UINT8_MAX	(INT8_MAX * 2 + 1)
 #define INT16_MAX	0x7fff
 #define INT16_MIN	(-INT16_MAX - 1)
-#define UINT16_MAX	(__CONCAT(INT16_MAX, U) * 2U + 1U)
+#define UINT16_MAX	(((unsigned)INT16_MAX) * 2U + 1U)
 #define INT32_MAX	0x7fffffffL
 #define INT32_MIN	(-INT32_MAX - 1L)
-#define UINT32_MAX	(__CONCAT(INT32_MAX, U) * 2UL + 1UL)
+#define UINT32_MAX	(((unsigned)INT32_MAX) * 2UL + 1UL)
 #define INT64_MAX	0x7fffffffffffffffLL
 #define INT64_MIN	(-INT64_MAX - 1LL)
-#define UINT64_MAX	(__CONCAT(INT64_MAX, U) * 2ULL + 1ULL)
+#define UINT64_MAX	(((unsigned)INT64_MAX) * 2ULL + 1ULL)
 
 #endif  // ELVM_LIBC_STDINT_H_

--- a/libc/stdint.h
+++ b/libc/stdint.h
@@ -24,6 +24,6 @@ typedef long time_t;
 #define UINT32_MAX	(((unsigned)INT32_MAX) * 2UL + 1UL)
 #define INT64_MAX	0x7fffffffffffffffLL
 #define INT64_MIN	(-INT64_MAX - 1LL)
-#define UINT64_MAX	(((unsigned)INT64_MAX) * 2ULL + 1ULL)
+#define UINT64_MAX	(((unsigned long long)INT64_MAX) * 2ULL + 1ULL)
 
 #endif  // ELVM_LIBC_STDINT_H_


### PR DESCRIPTION
I was receiving a compilation error from 8cc ("stdint.h:24:44: undefined variable: U"). I'm not sure if this was from __CONCAT not being defined. Manually casting resolved the error. I am not sure what other consequences would be from this change. I do not believe this should have an impact but backends are varied and I've seen how tricky things can be.

For testing I ran "make c" and noted that forward progress was made.