### PR TITLE
Use inttypes for printing uint64_t

### DIFF
--- a/libc/inttypes.h
+++ b/libc/inttypes.h
@@ -3,4 +3,6 @@
 
 #include <stdint.h>
 
+#define PRIu64 "l"
+
 #endif  // ELVM_LIBC_INTTYPES_H_

--- a/target/wm.c
+++ b/target/wm.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -1458,7 +1459,7 @@ GenLabelStatic(
     //
     if (snprintf(Buffer,
                  Size,
-                 "%s_%0*lx",
+                 "%s_%0*" PRIu64 "x",
                  Note,
                  Width,
                  Value) < 0)


### PR DESCRIPTION
`GenLabelStatic` assumes uint64_t can be printed using `%l` which causes an error on platforms where this assumtion does not hold

```
target/wm.c: In function ‘GenLabelStatic’:
target/wm.c:1461:26: error: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 6 has type ‘uint64_t {aka long long unsigned int}’ [-Werror=format=]
                  "%s_%0*lx",
                      ~~~~^
                      %0*llx
```