### PR TITLE
Fix printf invokation in bfopt

### DIFF
--- a/tools/bfopt.cc
+++ b/tools/bfopt.cc
@@ -287,7 +287,7 @@ void run(const vector<Op*>& ops) {
       }
 
       case OP_COMMENT: {
-        fprintf(stderr, "TRACE %s %f %lu\n",
+        fprintf(stderr, "TRACE %s %f %zu\n",
                 op->comment.c_str(),
                 static_cast<double>(clock()) / CLOCKS_PER_SEC,
                 pc);


### PR DESCRIPTION
bfopt tool assumes `std::size_t` can be printed using the `%lu` format specifier, which breaks the build on platforms where this assumption does not hold

```
tools/bfopt.cc: In function ‘void run(const std::vector<Op*>&)’:
tools/bfopt.cc:293:19: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘size_t {aka unsigned int}’ [-Werror=format=]
                 pc);
                   ^
```