### PR TITLE
Add J backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ ELC_SRCS := \
 	hell.c \
 	hs.c \
 	i.c \
+	j.c \
 	java.c \
 	js.c \
 	lua.c \
@@ -553,6 +554,11 @@ include target.mk
 
 TARGET := tcl
 RUNNER := tclsh
+include target.mk
+
+TARGET := j
+RUNNER := jconsole
+CAN_BUILD := $(shell jconsole -js "echo i.4" -js "exit 0" 2>&1 | perl -ne 'print /^0 1 2 3/ ? 1 : 0')
 include target.mk
 
 test: $(TEST_RESULTS)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unlike LLVM bitcode, EIR is designed to be extremely simple, so
 there's more chance we can write a translator from EIR to an esoteric
 language.
 
-Currently, there are 45 backends:
+Currently, there are 46 backends:
 
 * Awk (by [@dubek](https://github.com/dubek/))
 * Bash
@@ -32,6 +32,7 @@ Currently, there are 45 backends:
 * Forth (by [@dubek](https://github.com/dubek/))
 * Go (by [@shogo82148](https://github.com/shogo82148/))
 * HeLL (by [@esoteric-programmer](https://github.com/esoteric-programmer/))
+* J (by [@dubek](https://github.com/dubek/))
 * Java
 * JavaScript
 * LLVM IR (by [@retrage](https://github.com/retrage/))

--- a/target/elc.c
+++ b/target/elc.c
@@ -24,6 +24,7 @@ void target_go(Module* module);
 void target_hell(Module* module);
 void target_hs(Module* module);
 void target_i(Module* module);
+void target_j(Module* module);
 void target_java(Module* module);
 void target_js(Module* module);
 void target_lua(Module* module);
@@ -84,6 +85,7 @@ static target_func_t get_target_func(const char* ext) {
   if (!strcmp(ext, "hell")) return target_hell;
   if (!strcmp(ext, "hs")) return target_hs;
   if (!strcmp(ext, "i")) return target_i;
+  if (!strcmp(ext, "j")) return target_j;
   if (!strcmp(ext, "java")) return target_java;
   if (!strcmp(ext, "js")) return target_js;
   if (!strcmp(ext, "lua")) return target_lua;

--- a/target/j.c
+++ b/target/j.c
@@ -1,0 +1,164 @@
+#include <ir/ir.h>
+#include <target/util.h>
+
+static const char* j_cmp_str(Inst* inst) {
+  int op = normalize_cond(inst->op, 0);
+  const char* op_str;
+  switch (op) {
+    case JEQ:
+      op_str = "="; break;
+    case JNE:
+      op_str = "~:"; break;
+    case JLT:
+      op_str = "<"; break;
+    case JGT:
+      op_str = ">"; break;
+    case JLE:
+      op_str = "<:"; break;
+    case JGE:
+      op_str = ">:"; break;
+    case JMP:
+      return "1";
+    default:
+      error("oops");
+  }
+  return format("%s %s %s", reg_names[inst->dst.reg], op_str, src_str(inst));
+}
+
+static void j_init_state(void) {
+  for (int i = 0; i < 7; i++) {
+    emit_line("%s=: 0", reg_names[i]);
+  }
+  emit_line("mem=: 16777216 $ 0");
+  emit_line("input=: 1!:1@3 ''");
+  emit_line("pos=: 0");
+  emit_line("getc=: 3 : 0");
+  emit_line("if. pos >: ($ input) do. 0 return. end.");
+  emit_line("pos=: >:pos");
+  emit_line("a. i. ((<:pos) { input)");
+  emit_line(")");
+}
+
+static void j_emit_func_prologue(int func_id) {
+  emit_line("");
+  emit_line("func%d=: 3 : 0", func_id);
+  emit_line("while. ((%d <: pc) *. (pc < %d)) do.",
+            func_id * CHUNKED_FUNC_SIZE, (func_id + 1) * CHUNKED_FUNC_SIZE);
+  inc_indent();
+  emit_line("select. pc");
+  emit_line("case. _1 do.");
+  inc_indent();
+}
+
+static void j_emit_func_epilogue(void) {
+  dec_indent();
+  emit_line("end.");
+  emit_line("pc=: >:pc");
+  dec_indent();
+  emit_line("end.");
+  emit_line(")");
+}
+
+static void j_emit_pc_change(int pc) {
+  dec_indent();
+  emit_line("case. %d do.", pc);
+  inc_indent();
+}
+
+static void j_emit_inst(Inst* inst) {
+  switch (inst->op) {
+  case MOV:
+    emit_line("%s=: %s", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case ADD:
+    emit_line("%s=: (%s + %s) (17 b.) " UINT_MAX_STR,
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case SUB:
+    emit_line("%s=: (%s - %s) (17 b.) " UINT_MAX_STR,
+              reg_names[inst->dst.reg],
+              reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case LOAD:
+    emit_line("%s=: %s { mem", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case STORE:
+    emit_line("mem=: %s (%s)} mem", reg_names[inst->dst.reg], src_str(inst));
+    break;
+
+  case PUTC:
+    emit_line("tmoutput (%s { a.)", src_str(inst));
+    break;
+
+  case GETC:
+    emit_line("%s=: getc''", reg_names[inst->dst.reg]);
+    break;
+
+  case EXIT:
+    emit_line("exit 0");
+    break;
+
+  case DUMP:
+    break;
+
+  case EQ:
+  case NE:
+  case LT:
+  case GT:
+  case LE:
+  case GE:
+    emit_line("%s=: %s", reg_names[inst->dst.reg], j_cmp_str(inst));
+    break;
+
+  case JEQ:
+  case JNE:
+  case JLT:
+  case JGT:
+  case JLE:
+  case JGE:
+  case JMP:
+    emit_line("if. %s do. pc=: %s - 1 end.",
+              j_cmp_str(inst), value_str(&inst->jmp));
+    break;
+
+  default:
+    error("oops");
+  }
+}
+
+void target_j(Module* module) {
+  j_init_state();
+
+  int num_funcs = emit_chunked_main_loop(module->text,
+                                         j_emit_func_prologue,
+                                         j_emit_func_epilogue,
+                                         j_emit_pc_change,
+                                         j_emit_inst);
+
+  Data* data = module->data;
+  for (int mp = 0; data; data = data->next, mp++) {
+    if (data->v) {
+      emit_line("mem=: %d (%d)} mem", data->v, mp);
+    }
+  }
+
+  emit_line("");
+  emit_line("main=: 3 : 0");
+  emit_line("while. 1 do.");
+  inc_indent();
+  emit_line("select. pc <.@%% %d", CHUNKED_FUNC_SIZE);
+  for (int i = 0; i < num_funcs; i++) {
+    emit_line("case. %d do. func%d''", i, i);
+  }
+  emit_line("end.");
+  dec_indent();
+  emit_line("end.");
+  emit_line(")");
+  emit_line("main''");
+  emit_line("exit 1");
+}


### PR DESCRIPTION
Add J backend to ELVM. Passes all tests:

```
make j
make test-j-full
```

This was tested on Linux with J version [J901](https://code.jsoftware.com/wiki/System/Installation/J901/Zips).

Note that the command that runs J scripts is called `jconsole`, and it should not be confused with `jconsole` that is part of the Java JDK/JRE packages.  That's why I added the `CAN_BUILD` definition in Makefile.
