### PR TITLE
Fix implementation of fgets

### DIFF
--- a/libc/stdio.h
+++ b/libc/stdio.h
@@ -163,26 +163,6 @@ int fputs(const char* s, FILE* fp) {
   print_str(s);
 }
 
-char* fgets(char* s, int size, FILE* fp) {
-  int i;
-  for (i = 0; i < size - 1;) {
-    int c = getchar();
-    if (c == EOF) {
-      break;
-    }
-    s[i++] = c;
-    if (c == '\n') {
-      break;
-    }
-  }
-  if (i) {
-    s[i] = 0;
-    return s;
-  } else {
-    return 0;
-  }
-}
-
 static int g_ungot = EOF;
 static int eof_seen;
 
@@ -218,6 +198,26 @@ int fputc(int c, FILE* fp) {
 
 int putc(int c, FILE* fp) {
   return putchar(c);
+}
+
+char* fgets(char* s, int size, FILE* fp) {
+  int i;
+  for (i = 0; i < size - 1;) {
+    int c = fgetc(fp);
+    if (c == EOF) {
+      break;
+    }
+    s[i++] = c;
+    if (c == '\n') {
+      break;
+    }
+  }
+  if (i) {
+    s[i] = 0;
+    return s;
+  } else {
+    return 0;
+  }
 }
 
 #endif  // ELVM_LIBC_STDIO_H_

--- a/libc/stdio.h
+++ b/libc/stdio.h
@@ -163,17 +163,24 @@ int fputs(const char* s, FILE* fp) {
   print_str(s);
 }
 
-int fgets(char* s, int size, FILE* fp) {
-  for (int i = 0; i < size - 1; i++) {
+char* fgets(char* s, int size, FILE* fp) {
+  int i;
+  for (i = 0; i < size - 1;) {
     int c = getchar();
-    s[i] = c;
-    if (c == '\n' || c == EOF) {
-      s[i + 1] = 0;
-      return i;
+    if (c == EOF) {
+      break;
+    }
+    s[i++] = c;
+    if (c == '\n') {
+      break;
     }
   }
-  s[size - 1] = 0;
-  return size;
+  if (i) {
+    s[i] = 0;
+    return s;
+  } else {
+    return 0;
+  }
 }
 
 static int g_ungot = EOF;

--- a/test/fgets.c
+++ b/test/fgets.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int main() {
+  char buf[256];
+  char* ptr = fgets(buf, 100, stdin);
+  printf("%d\n", ptr == buf);
+  printf("%s\n", ptr);
+  ptr = fgets(buf, 100, stdin);
+  printf("%d\n", ptr == buf);
+  printf("%s\n", ptr);
+  ptr = fgets(buf, 100, stdin);
+  printf("%d\n", ptr == 0);
+  return 0;
+}

--- a/test/fgets.in
+++ b/test/fgets.in
@@ -1,0 +1,2 @@
+foobar
+baz


### PR DESCRIPTION
It should return char*, not int. Pointed out in #96.

Also let `fgets` call `fgetc` so that the EOF hack for whitespace is used in `fgets`.