### PR TITLE
Add strcspn implementation

### DIFF
--- a/libc/string.h
+++ b/libc/string.h
@@ -216,4 +216,24 @@ strpbrk(const char *s1, const char *s2)
 	return (NULL);
 }
 
+// From Bionic:
+size_t
+strcspn(const char *s1, const char *s2)
+{
+	const char *p, *spanp;
+	char c, sc;
+	/*
+	 * Stop as soon as we find any character from s2.  Note that there
+	 * must be a NULL in s2; it suffices to stop when we find that, too.
+	 */
+	for (p = s1;;) {
+		c = *p++;
+		spanp = s2;
+		do {
+			if ((sc = *spanp++) == c)
+				return (p - 1 - s1);
+		} while (sc != 0);
+	}
+	/* NOTREACHED */
+}
 #endif  // ELVM_LIBC_STRING_H_


### PR DESCRIPTION
I thought of implementing it using a 256-bit bitmap. Like storing characters in `s2` like a blacklist to stop iteration of `s1`. However, it might be an overkill to create a bitmap for overall use-cases. Under most circumstances, the length of `s2` should be way smaller than `s1`. Thus, I decided to copy the implementation from Bionic like some other functions in `string.h`.

I was planning to write some test cases, but I noticed there are no test cases for functions like `strchr` and the test structure looked a bit weird to me. It might be better to refactor the tests at some point. Still, I can write tests similar to `fgets` if you'd like.