### PR TITLE
Save TeX's main memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,9 +324,6 @@ include target.mk
 TARGET := tex
 RUNNER := tools/runtex.sh
 TOOL := tex
-# It seems tex backend does not work for elc anymore.
-# TODO(hamaji): Fix this.
-TEST_FILTER += out/elc.c.eir.tex
 include target.mk
 
 TARGET := cl


### PR DESCRIPTION
fix #106 

I've changed the output to not consume too much of TeX's main memory.
I have confirmed that `make tex` and `make elc-tex` work.