### PR TITLE
Add computed goto feature

### DIFF
--- a/test/computed_goto.c
+++ b/test/computed_goto.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+void* label_return;
+
+int main() {
+  void* label_array[] = {&&label_a, &&label_b, &&label_c};
+
+  int label_array_relative[] = {
+    &&label_a - &&label_a,
+    &&label_b - &&label_a,
+    &&label_c - &&label_a,
+  };
+
+label_0:
+  label_return = &&label_1;
+  goto *label_array[0];
+
+label_1:
+  label_return = &&label_2;
+  goto *label_array[1];
+
+label_2:
+  label_return = &&label_3;
+  goto *label_array[2];
+
+label_3:
+  label_return = &&label_4;
+  goto *(label_array_relative[0] + &&label_a);
+
+label_4:
+  label_return = &&label_5;
+  goto *(label_array_relative[1] + &&label_a);
+
+label_5:
+  label_return = &&label_6;
+  goto *(label_array_relative[2] + &&label_a);
+
+label_6:
+  goto *(&&label_end);
+
+label_a:
+  printf("label_a\n");
+  goto *label_return;
+
+label_b:
+  printf("label_b\n");
+  goto *label_return;
+
+label_c:
+  printf("label_c\n");
+  goto *label_return;
+
+label_end:
+  return 0;
+}


### PR DESCRIPTION
This pull request depends on [this](https://github.com/shinh/8cc/pull/3) pull request from the 8cc submodule, so another commit to renew the submodule pointer should be made.

The computed goto feature (and the "Labels as Values" feature) allows the address of `goto` labels to be stored in `void*` pointers, and allows jumping to them by writing code such as `goto *ptr;`, as described [here](https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html).

Although this is a non-standard feature, the original 8cc implements this through `emit_label_addr` and `emit_computed_goto`. However, these functions were left as is from the original 8cc code and also didn't have any tests, being left as unimplemented. Although 8cc finishes without errors when using this syntax, the compiled EIR causes an error when compiled by ELC.

I have made a separate pull request in the 8cc repository that adds this feature. This pull request here in the ELVM repository adds a test for the computed goto feature.

I ran the tests on Ubuntu (`gcc 9.3.0`) and on a Mac (`Apple clang version 12.0.0`), with `make && make build-py && make test-py`.