### PR TITLE
-Werror compatibility for newer versions of GCC

### DIFF
--- a/ir/ir.c
+++ b/ir/ir.c
@@ -242,17 +242,17 @@ static Op get_op(Parser* p, const char* buf) {
   } else if (!strcmp(buf, "ge")) {
     return GE;
   } else if (!strcmp(buf, ".text")) {
-    return TEXT;
+    return (Op)TEXT;
   } else if (!strcmp(buf, ".data")) {
-    return DATA;
+    return (Op)DATA;
   } else if (!strcmp(buf, ".long")) {
-    return LONG;
+    return (Op)LONG;
   } else if (!strcmp(buf, ".string")) {
-    return STRING;
+    return (Op)STRING;
   } else if (!strcmp(buf, ".file")) {
-    return FILENAME;
+    return (Op)FILENAME;
   } else if (!strcmp(buf, ".loc")) {
-    return LOC;
+    return (Op)LOC;
   }
   return OP_UNSET;
 }
@@ -332,7 +332,7 @@ static void parse_line(Parser* p, int c) {
         p->symtab = table_add(p->symtab, strdup(buf), (void*)value);
       } else {
         DataPrivate* d = add_data(p);
-        d->val.type = LABEL;
+        d->val.type = (ValueType)LABEL;
         d->val.tmp = strdup(buf);
       }
       return;
@@ -411,7 +411,7 @@ static void parse_line(Parser* p, int c) {
       add_imm_data(p, args[0].imm);
     } else if (args[0].type == (ValueType)REF) {
       DataPrivate* d = add_data(p);
-      d->val.type = REF;
+      d->val.type = (ValueType)REF;
       d->val.tmp = args[0].tmp;
     } else {
       ir_error(p, "number expected");


### PR DESCRIPTION
Fixes #87. Currently, running `make` causes 8 errors from GCC due to warnings being applied as errors through the `-Werror` flag. I was able to reproduce the same errors mentioned in the image in #87.

All of the errors are `-Werror=enum-conversion`, where enums are implicitly casted to the enum `Op`.

This pull request fixes this by simply casting enums with the function's return type. Since all casts are enum-to-enum casts I think this is the safest solution.

I've tested this fix on the x86 backend. I've confirmed that all of the following tests, including the self-hosting test, runs successfully on my machine:

- `make x86`
- `make test-x86-full`
- `tools/check_selfhost.sh x86`