### PR TITLE
Add Acc!! backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ $(COBJS): out/%.o: ir/%.c
 ELC_SRCS := \
 	elc.c \
 	util.c \
+	acc.c \
 	aheui.c \
 	asmjs.c \
 	arm.c \
@@ -432,6 +433,12 @@ $(OUT.eir.ws.out): tools/runws.sh Whitespace/whitespace.out tinycc/tcc
 TARGET := aheui
 RUNNER := rpaheui-c
 TEST_FILTER := out/elc.c.eir.aheui
+include target.mk
+
+TARGET := acc
+RUNNER := tools/runacc.sh
+# Acc interpreter struggles when more than a few kilobytes of memory is used
+TEST_FILTER := $(addsuffix .acc,$(filter out/%.c.eir,$(OUT.eir))) out/04getc.eir.acc
 include target.mk
 
 TARGET := bef

--- a/Makefile
+++ b/Makefile
@@ -437,8 +437,7 @@ include target.mk
 
 TARGET := acc
 RUNNER := tools/runacc.sh
-# Acc interpreter struggles when more than a few kilobytes of memory is used
-TEST_FILTER := $(addsuffix .acc,$(filter out/%.c.eir,$(OUT.eir))) out/04getc.eir.acc
+TEST_FILTER := out/04getc.eir.acc out/switch_case.c.eir.acc out/switch_op.c.eir.acc out/switch_range.c.eir.acc out/24_cmp.c.eir.acc out/24_cmp2.c.eir.acc out/24_muldiv.c.eir.acc out/bitops.c.eir.acc out/copy_struct.c.eir.acc out/computed_goto.c.eir.acc out/eof.c.eir.acc out/fgets.c.eir.acc out/fizzbuzz.c.eir.acc out/fizzbuzz_fast.c.eir.acc out/global_struct_ref.c.eir.acc out/lisp.c.eir.acc out/muldiv.c.eir.acc out/printf.c.eir.acc out/print_int.c.eir.acc out/qsort.c.eir.acc out/8cc.c.eir.acc out/elc.c.eir.acc out/dump_ir.c.eir.acc out/eli.c.eir.acc out/bool.c.eir.acc out/field_addr.c.eir.acc.out.time
 include target.mk
 
 TARGET := bef

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ language.
 
 Currently, there are 60 backends:
 
+1. *Acc!!*
 1. Aheui
 1. Awk (by [@dubek](https://github.com/dubek/))
 1. Bash

--- a/target/acc.c
+++ b/target/acc.c
@@ -1,0 +1,183 @@
+//                 Program Counter | A           | B           | C           | D           | BP          | SP          | mem[idx]
+// Memory layout: -----------------+-------------+-------------+-------------+-------------+-------------+-------------+----------------------
+//                 _%2^24          | _/4^12%2^24 | _/4^24%2^24 | _/4^36%2^24 | _/4^48%2^24 | _/4^60%2^24 | _/4^72%2^24 | _/2^(24*(7+idx))%2^24
+
+#include <ir/ir.h>
+#include <target/util.h>
+
+static int ignore_inst = false;
+
+static const char* acc_value_str(Value* v) {
+  if (v->type == REG) {
+    return format("_/4^%d%%2^24", 12 * (v->reg + 1));
+  } else if (v->type == IMM) {
+    return format("%d", v->imm);
+  } else {
+    error("invalid value");
+  }
+}
+
+static const char* acc_mem_str(const char* idx) {
+  return format("_/2^(24*(7+%s))%%2^24", idx);
+}
+
+static const char* acc_cmp_str(Inst* inst) {
+  int op = normalize_cond(inst->op, 0);
+  switch (op) {
+    case JEQ:
+      return format("0^((%s-%s)%%2^24)", acc_value_str(&inst->src), acc_value_str(&inst->dst));
+    case JNE:
+      return format("(1-0^((%s-%s)%%2^24))", acc_value_str(&inst->src), acc_value_str(&inst->dst));
+
+    case JLT:
+      return format("0^((%s+1)/(%s+1))", acc_value_str(&inst->dst), acc_value_str(&inst->src));
+    case JGT:
+      return format("0^((%s+1)/(%s+1))", acc_value_str(&inst->src), acc_value_str(&inst->dst));
+
+    case JLE:
+      return format("0^(%s/(%s+1))", acc_value_str(&inst->dst), acc_value_str(&inst->src));
+    case JGE:
+      return format("0^(%s/(%s+1))", acc_value_str(&inst->src), acc_value_str(&inst->dst));
+
+    default:
+      error("oops");
+  }
+}
+
+static void acc_emit_func_prologue(int func_id) {
+  emit_line("Count b while _*0^((_%%2^24-1)/%d-%d)^2 {", CHUNKED_FUNC_SIZE, func_id);
+  inc_indent();
+  emit_line("Count c while 0 {  # dummy");
+  inc_indent();
+}
+
+static void acc_emit_func_epilogue(void) {
+  emit_line("_+1");
+  dec_indent();
+  emit_line("}");
+  dec_indent();
+  emit_line("}");
+}
+
+static void acc_emit_pc_change(int pc) {
+  ignore_inst = false;
+
+  emit_line("_+1");
+  dec_indent();
+  emit_line("}");
+  emit_line("");
+  emit_line("Count c while 0^((_-%d)%%2^24) {", pc + 1);
+  inc_indent();
+}
+
+static void acc_emit_inst(Inst* inst) {
+  if (ignore_inst) return;
+
+  switch (inst->op) {
+  case MOV:
+    emit_line("_+(%s-%s)*4^%d",
+              acc_value_str(&inst->src),
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case ADD:
+    emit_line("_+((%s+%s)%%2^24-%s)*4^%d",
+              acc_value_str(&inst->src),
+              acc_value_str(&inst->dst),
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case SUB:
+    emit_line("_+((%s-%s)%%2^24-%s)*4^%d",
+              acc_value_str(&inst->dst),
+              acc_value_str(&inst->src),
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case LOAD:
+    emit_line("_+(%s-%s)*4^%d",
+              acc_mem_str(acc_value_str(&inst->src)),
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case STORE:
+    emit_line("_+(%s-%s)*2^(24*(7+%s))",
+              acc_value_str(&inst->dst),
+              acc_mem_str(acc_value_str(&inst->src)),
+              acc_value_str(&inst->src));
+    break;
+
+  case PUTC:
+    emit_line("Write %s", acc_value_str(&inst->src));
+    break;
+
+  case GETC:
+    emit_line("_+(N-%s)*4^%d",
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case EXIT:
+    emit_line("-1");
+    ignore_inst = true;
+    break;
+
+  case DUMP:
+    break;
+
+  case EQ:
+  case NE:
+  case LT:
+  case GT:
+  case LE:
+  case GE:
+    emit_line("_+(%s-%s)*4^%d",
+              acc_cmp_str(inst),
+              acc_value_str(&inst->dst),
+              12 * (inst->dst.reg + 1));
+    break;
+
+  case JEQ:
+  case JNE:
+  case JLT:
+  case JGT:
+  case JLE:
+  case JGE:
+    emit_line("_+%s*(%s-_%%2^24)", acc_cmp_str(inst), acc_value_str(&inst->jmp));
+    break;
+
+  case JMP:
+    emit_line("_-_%%2^24+%s", acc_value_str(&inst->jmp));
+    break;
+
+  default:
+    break;
+  }
+}
+
+void target_acc(Module* module) {
+  emit_line("1");
+
+  Data* data = module->data;
+  for (int mp = 0; data; data = data->next, mp++) {
+    if (data->v) {
+      emit_line("_+%d*4^%d", data->v, 12 * (mp + 7));
+    }
+  }
+
+  emit_line("Count a while _ {");
+  inc_indent();
+
+  emit_chunked_main_loop(module->text,
+                         acc_emit_func_prologue,
+                         acc_emit_func_epilogue,
+                         acc_emit_pc_change,
+                         acc_emit_inst);
+
+  dec_indent();
+  emit_line("}");
+}

--- a/target/elc.c
+++ b/target/elc.c
@@ -5,6 +5,7 @@
 #include <ir/ir.h>
 #include <target/util.h>
 
+void target_acc(Module* module);
 void target_aheui(Module* module);
 void target_arm(Module* module);
 void target_asmjs(Module* module);
@@ -74,6 +75,7 @@ void target_x86(Module* module);
 typedef void (*target_func_t)(Module*);
 
 static target_func_t get_target_func(const char* ext) {
+  if (!strcmp(ext, "acc")) return target_acc;
   if (!strcmp(ext, "aheui")) return target_aheui;
   if (!strcmp(ext, "arm")) return target_arm;
   if (!strcmp(ext, "asmjs")) return target_asmjs;

--- a/tools/run_acc.py
+++ b/tools/run_acc.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python3
+
+import re
+import sys
+
+def main(codeFile=None):
+    if len(sys.argv) > 1:
+        codeFile = sys.argv[1]
+    elif codeFile is None:
+        codeFile = input("Please supply a filename: ")
+    try:
+        with open(codeFile) as f:
+            code = f.readlines()
+        code = translate(code)
+        exec(code, {"inputStream": inputStream()})
+    except:
+        print("Acc!!\n", file=sys.stderr)
+        raise
+
+def inputStream():
+    buffer = ""
+    while True:
+        if buffer == "":
+            try:
+                buffer = input() + "\n"
+            except EOFError:
+                buffer = None
+        if buffer is None:
+            yield 0
+        else:
+            yield ord(buffer[0])
+            buffer = buffer[1:]
+
+def translate(accCode):
+    indent = 0
+    loopVars = []
+    pyCode = ["_ = 0"]
+    for lineNum, line in enumerate(accCode):
+        if "#" in line:
+            # Strip comments
+            line = line[:line.index("#")]
+        line = line.strip()
+        if not line:
+            continue
+        lineNum += 1
+        if line == "}":
+            if indent:
+                loopVar = loopVars.pop()
+                pyCode.append(" "*indent + loopVar + " += 1")
+                indent -= 1
+                pyCode.append(" "*indent + "del " + loopVar)
+            else:
+                raise SyntaxError("Line %d: unmatched }" % lineNum)
+        else:
+            m = re.fullmatch(r"Count ([a-z]) while (.+) \{", line)
+            if m:
+                expression = validateExpression(m.group(2))
+                if expression:
+                    loopVar = m.group(1)
+                    pyCode.append(" "*indent + loopVar + " = 0")
+                    pyCode.append(" "*indent + "while " + expression + ":")
+                    indent += 1
+                    loopVars.append(loopVar)
+                else:
+                    raise SyntaxError("Line %d: invalid expression " % lineNum
+                                      + m.group(2))
+            else:
+                m = re.fullmatch(r"Write (.+)", line)
+                if m:
+                    expression = validateExpression(m.group(1))
+                    if expression:
+                        pyCode.append(" "*indent
+                                      + "print(chr(%s), end='')" % expression)
+                    else:
+                        raise SyntaxError("Line %d: invalid expression "
+                                          % lineNum
+                                          + m.group(1))
+                else:
+                    expression = validateExpression(line)
+                    if expression:
+                        pyCode.append(" "*indent + "_ = " + expression)
+                    else:
+                        raise SyntaxError("Line %d: invalid statement "
+                                          % lineNum
+                                          + line)
+    return "\n".join(pyCode)
+
+def validateExpression(expr):
+    "Translates expr to Python expression or returns None if invalid."
+    expr = expr.strip()
+    if re.search(r"[^ 0-9a-z_N()*/%^+-]", expr):
+        # Expression contains invalid characters
+        return None
+    elif re.search(r"[a-zN_]\w+", expr):
+        # Expression contains multiple letters or underscores in a row
+        return None
+    else:
+        # Not going to check validity of all identifiers or nesting of parens--
+        # let the Python code throw an error if problems arise there
+        # Replace short operators with their Python versions
+        expr = expr.replace("^", "**")
+        expr = expr.replace("/", "//")
+        # Replace N with a call to get the next input character
+        expr = expr.replace("N", "next(inputStream)")
+        return expr
+
+if __name__ == "__main__":
+    main()

--- a/tools/runacc.sh
+++ b/tools/runacc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python3 "tools/run_acc.py" $1


### PR DESCRIPTION
This PR adds a backend for [*Acc!!*](https://esolangs.org/wiki/Acc!!), an esoteric programming language centered around a single accumulator.

Due to the nature of *Acc!!*, all instructions experience significant slowdowns when operating with large memory addresses. Consequently, several tests that take more than 10 minutes to complete have been disabled. Additionally, the official interpreter automatically inserts missing newlines before EOF on stdin, which affects tests that read until EOF. Therefore, all such tests have also been disabled.

To determine if additional tests should be disabled, I have compiled a table of tests that take longer than a minute. Please review the table below and provide feedback on whether these tests should also be disabled:
```
array.c.eir.acc            0m52.767s
global_array.c.eir.acc     1m5.678s
func2.c.eir.acc            1m11.358s
func_ptr.c.eir.acc         1m5.136s
hello.c.eir.acc            2m7.707s
loop.c.eir.acc             4m2.989s
puts.c.eir.acc             4m24.472s
func.c.eir.acc             5m1.941s
logic_val.c.eir.acc        5m38.624s
increment.c.eir.acc        6m14.044s
malloc.c.eir.acc           8m2.808s
```