### PR TITLE
Fixed SUBLEQ's 8cc test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,6 @@ include target.mk
 
 TARGET := subleq
 RUNNER := out/subleq
-TEST_FILTER := out/8cc.c.eir.subleq
 include target.mk
 
 TARGET := ps


### PR DESCRIPTION
Fixed issue where moving a register from itself would cause the SUBLEQ target to fail, and removed 8cc from the SUBLEQ test filter. Also fixed some memory leaks.