### PR TITLE
Convert bash backend to POSIX shell backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Currently, there are 60 backends:
 1. *Acc!!*
 1. Aheui
 1. Awk (by [@dubek](https://github.com/dubek/))
-1. Bash
 1. Befunge
 1. Binary Lambda Calculus (by [@woodrush](https://github.com/woodrush/))
 1. Brainfuck
@@ -52,6 +51,7 @@ Currently, there are 60 backends:
 1. Perl5 (by [@mackee](https://github.com/mackee/))
 1. PHP (by [@zonuexe](https://github.com/zonuexe/))
 1. Piet
+1. POSIX Shell
 1. Python
 1. Ruby
 1. Scheme syntax-rules (by [@zeptometer](https://github.com/zeptometer/))

--- a/target/sh.c
+++ b/target/sh.c
@@ -2,6 +2,7 @@
 #include <target/util.h>
 
 static void sh_init_state(Data* data) {
+  emit_line("#! /bin/sh");
   for (int i = 0; i < 7; i++) {
     emit_line("%s=0", reg_names[i]);
   }

--- a/target/sh.c
+++ b/target/sh.c
@@ -70,12 +70,11 @@ static void sh_emit_inst(Inst* inst) {
     break;
 
   case LOAD:
-    emit_line("eval z=\\$m%s", sh_src_str(inst));
-    emit_line("%s=$(( $z + 0 ))", reg_names[inst->dst.reg]);
+    emit_line(": $(( %s = m%s + 0 ))", reg_names[inst->dst.reg], sh_src_str(inst));
     break;
 
   case STORE:
-    emit_line("eval m%s=$%s", sh_src_str(inst), reg_names[inst->dst.reg]);
+    emit_line(": $(( m%s = $%s ))", sh_src_str(inst), reg_names[inst->dst.reg]);
     break;
 
   case PUTC:

--- a/target/sh.c
+++ b/target/sh.c
@@ -78,8 +78,8 @@ static void sh_emit_inst(Inst* inst) {
     break;
 
   case PUTC:
-    emit_line("t=$((%s&255))", sh_src_str(inst));
-    emit_line("printf \"\\\\$(printf '%%03o' $t)\"");
+    emit_line(": $(( t = (%s & 255) ))", sh_src_str(inst));
+    emit_line("printf \\\\$((t/64))$((t/8%%8))$((t%%8))");
     break;
 
   case GETC:

--- a/target/sh.c
+++ b/target/sh.c
@@ -3,10 +3,8 @@
 
 static void sh_init_state(Data* data) {
   emit_line("#! /bin/sh");
-#ifdef POSIX_SHELL
   emit_line("GETC_BUF=\"\"");
   emit_line("GETC_BUF_ENDING=-1 # -1: uninit, 0: EOF, 10: newline");
-#endif
   for (int i = 0; i < 7; i++) {
     emit_line("%s=0", reg_names[i]);
   }
@@ -93,7 +91,6 @@ static void sh_emit_inst(Inst* inst) {
     break;
 
   case GETC:
-#ifdef POSIX_SHELL
     // The POSIX standard doesn't support read -n1, so we read a full line and buffer it.
     // The GETC state machines can be in 3 states:
     //   Non-empty GETC_BUF buffer: take first char from buffer
@@ -120,17 +117,6 @@ static void sh_emit_inst(Inst* inst) {
     emit_line(" %s=$(printf '%%d' \"'$t'\")", reg_names[inst->dst.reg]);
     emit_line(" break");
     emit_line("done");
-#else
-    emit_line("if read -rn1 t; then");
-    emit_line(" if [ -z $t ]; then");
-    emit_line("  %s=10", reg_names[inst->dst.reg]);
-    emit_line(" else");
-    emit_line("  %s=$(printf '%%d' \"'$t'\")", reg_names[inst->dst.reg]);
-    emit_line(" fi");
-    emit_line("else");
-    emit_line(" %s=0", reg_names[inst->dst.reg]);
-    emit_line("fi");
-#endif
     break;
 
   case EXIT:


### PR DESCRIPTION
I looked at the bash backend and saw that it generated code that was almost portable across shells. This PR makes the output of the bash backend conform to the POSIX specification. It also replaces the 2 `eval` calls with simpler nested arithmetic and improve performance.