### PR TITLE
gnufind: run scratch dir on tmpfs when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,20 @@ Implementation details are described in the [GrassVM](https://github.com/woodrus
 This backend is tested with the Grass interpreter [grass.ml](https://gist.github.com/woodrush/3d85a6569ef3c85b63bfaf9211881af6), originally written by [@ytomino](https://github.com/ytomino) and modified by [@youz](https://github.com/youz) and [@woodrush](https://github.com/woodrush).
 The modifications are described in the [GrassVM](https://github.com/woodrush/grassvm) repository.
 
+### GNU find
+
+The [GNU find](https://www.gnu.org/software/findutils/) backend was contributed by [@ogiekako](https://github.com/ogiekako/).
+
+This backend compiles a program into a single shell script, which is nothing but
+a few `find` invocations, each of which in turn `-exec`s only more `find`. All
+program state lives as files in a scratch directory. See the
+[commit message](https://github.com/shinh/elvm/commit/4e42a7103583eae2edf0f1df35f0649c94354340)
+for details. It is very slow, so only a subset of tests runs by default. Run
+more (very slowly) with `FULL=1 make gnufind`.
+
+The scratch directory's parent can be overridden with `GF_TMPDIR` (or
+`TMPDIR`); by default an in-memory filesystem (`/dev/shm`) is preferred when
+available and `/tmp` otherwise.
 
 ## Future works
 

--- a/tools/rungnufind.sh
+++ b/tools/rungnufind.sh
@@ -4,9 +4,22 @@ set -e
 
 PROG="$PWD/$1"
 
-DIR=$(mktemp -d gnufind_elvm.XXXXXXXXXX --tmpdir)
+# gnufind churns through a large number of tiny files, so prefer an
+# in-memory filesystem (tmpfs) for the scratch directory when one is available:
+# it is a bit faster and avoids wearing the SSD. Order of preference:
+#   GF_TMPDIR (explicit override) > TMPDIR > tmpfs (/dev/shm) > /tmp
+if [[ -n "${GF_TMPDIR}" ]]; then
+  GF_PARENT="${GF_TMPDIR}"
+elif [[ -n "${TMPDIR}" ]]; then
+  GF_PARENT="${TMPDIR}"
+elif [[ -d /dev/shm && -w /dev/shm ]]; then
+  GF_PARENT=/dev/shm
+else
+  GF_PARENT=/tmp
+fi
+DIR=$(mktemp -d "${GF_PARENT}/gnufind_elvm.XXXXXXXXXX")
 cd "$DIR"
-trap "rm -rf $DIR" EXIT
+trap 'rm -rf "$DIR"' EXIT
 
 ERR=/dev/null
 if [[ ! -z "${GF_DEBUG}" ]]; then


### PR DESCRIPTION
The gnufind runner creates and removes a large number of tiny files
under a scratch directory. When that directory lives on a disk-backed
filesystem this needlessly wears the SSD and is a bit slower.

This makes `tools/rungnufind.sh` prefer an in-memory filesystem (tmpfs)
for the scratch directory when one is available:

    GF_TMPDIR (explicit override) > TMPDIR > /dev/shm (tmpfs) > /tmp

It falls back to /tmp when /dev/shm is absent, so behavior is unchanged where tmpfs is unavailable. The
check is existence + writability, not the mount type, so correctness
never depends on it; the location can be overridden with GF_TMPDIR (or
TMPDIR).

On one machine this cut `make gnufind` wall time from 4m13s to 3m42s (~12%).

This also adds a brief explanation about the gnufind backend in README.md.